### PR TITLE
Fixed Client_Print to correctly remove colour tags when outputting to colour-unsupported console.

### DIFF
--- a/scripting/include/smlib/clients.inc
+++ b/scripting/include/smlib/clients.inc
@@ -2011,8 +2011,7 @@ stock Client_Print(client, ClientHudPrint:destination, const String:format[], an
 		(destination != ClientHudPrint_Console) ||
 		(destination == ClientHudPrint_Console && GuessSDKVersion() < SOURCE_SDK_LEFT4DEAD))
 	{
-		Color_StripFromChatText(buffer, buffer2, sizeof(buffer2));
-		strcopy(buffer, sizeof(buffer), buffer2);
+		Color_StripFromChatText(buffer2, buffer, sizeof(buffer2));
 
 		if (client == 0) {
 			PrintToServer(buffer2);


### PR DESCRIPTION
In the previous code, `buffer` held the string with colour tags in it, and `buffer2` held the string with the colour tags converted to colour codes. Unfortunately, if it was discovered the console doesn't support colours, `Color_StripFromChatText` was called on `buffer`, so no colour codes or tags are removed, leaving things like "{N}" or "{R}" intact.
