### PR TITLE
Fixed String_ToLower invalid memory access error

### DIFF
--- a/scripting/include/smlib/strings.inc
+++ b/scripting/include/smlib/strings.inc
@@ -108,7 +108,7 @@ stock String_ToLower(const String:input[], String:output[], size)
 	size--;
 
 	new x=0;
-	while (input[x] != '\0' || x < size) {
+	while (input[x] != '\0' && x < size) {
 		
 		if (IsCharUpper(input[x])) {
 			output[x] = CharToLower(input[x]);
@@ -138,7 +138,7 @@ stock String_ToUpper(const String:input[], String:output[], size)
 	size--;
 
 	new x=0;
-	while (input[x] != '\0') {
+	while (input[x] != '\0' && x < size) {
 		
 		if (IsCharLower(input[x])) {
 			output[x] = CharToUpper(input[x]);


### PR DESCRIPTION
String_ToLower causes an invalid memory access error if the size of the String array `input` is less than `size`
