### PR TITLE
Redundant upper/lower-case checking in String_ToXXXXX functions

### DIFF
--- a/scripting/include/smlib/strings.inc
+++ b/scripting/include/smlib/strings.inc
@@ -110,12 +110,7 @@ stock String_ToLower(const String:input[], String:output[], size)
 	new x=0;
 	while (input[x] != '\0' && x < size) {
 		
-		if (IsCharUpper(input[x])) {
-			output[x] = CharToLower(input[x]);
-		}
-		else {
-			output[x] = input[x];
-		}
+		output[x] = CharToLower(input[x]);
 		
 		x++;
 	}
@@ -140,13 +135,8 @@ stock String_ToUpper(const String:input[], String:output[], size)
 	new x=0;
 	while (input[x] != '\0' && x < size) {
 		
-		if (IsCharLower(input[x])) {
-			output[x] = CharToUpper(input[x]);
-		}
-		else {
-			output[x] = input[x];
-		}
-
+		output[x] = CharToUpper(input[x]);
+		
 		x++;
 	}
 


### PR DESCRIPTION
The SourceMod `CharToXXXXX` stocks already include a check to ensure the character passed in is really upper/lowercase, so the check in smlib is not needed:

``` c
stock CharToUpper(chr)
{
    if (IsCharLower(chr))
    {
        return (chr & ~(1<<5));
    }
    return chr;
}

stock CharToLower(chr)
{
    if (IsCharUpper(chr))
    {
        return (chr | (1<<5));
    }
    return chr;
}
```
