### PR TITLE
Update some variable names that are now reserved keywords.

### DIFF
--- a/scripting/include/smlib/crypt.inc
+++ b/scripting/include/smlib/crypt.inc
@@ -10,7 +10,7 @@
  * Base64 Encoding/Decoding Functions
  * All Credits to to SirLamer & ScriptCoderPro
  * Taken from http://forums.alliedmods.net/showthread.php?t=101764
- * 
+ *
  ***********************************************************************************/
 
 // The Base64 encoding table
@@ -69,7 +69,7 @@ static const String:base64_url_chars[]	= "-_.";
  * @param sourcelen 	(optional): The number of characters or length in bytes to be read from the input source.
  *						This is not needed for a text string, but is important for binary data since there is no end-of-line character.
  * @return				The length of the written Base64 string, in bytes.
- */			
+ */
 stock Crypt_Base64Encode(const String:sString[], String:sResult[], len, sourcelen=0)
 {
 	new nLength;	// The string length to be read from the input
@@ -239,7 +239,7 @@ stock Crypt_Base64UrlToMime(const String:sString[], String:sResult[], len)
 	nLength = strlen(sString);
 
 	new String:sTemp[nLength+1]; // Buffer string
-	
+
 	// Loop through string
 	for (new i = 0; i < nLength; i++) {
 		temp_char = sString[i];
@@ -264,12 +264,12 @@ stock Crypt_Base64UrlToMime(const String:sString[], String:sResult[], len)
  * All Credits go to sslice
  * RSA Data Security, Inc. MD5 Message Digest Algorithm
  * Taken from http://forums.alliedmods.net/showthread.php?t=67683
- * 
+ *
  ***********************************************************************************/
 
 /*
  * Calculate the md5 hash of a string.
- * 
+ *
  * @param str			Input String
  * @param output		Output String Buffer
  * @param maxlen		Size of the Output String Buffer
@@ -292,10 +292,10 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 	buf[3] = 0x10325476;
 
 	// MD5Update
-	new in[16];
+	new update[16];
 
-	in[14] = x[0];
-	in[15] = x[1];
+	update[14] = x[0];
+	update[15] = x[1];
 
 	new mdi = (x[0] >>> 3) & 0x3F;
 
@@ -311,17 +311,17 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 		input[mdi] = str[c];
 		mdi += 1;
 		c += 1;
-		
+
 		if (mdi == 0x40) {
 
 			for (i = 0, ii = 0; i < 16; ++i, ii += 4)
 			{
-				in[i] = (input[ii + 3] << 24) | (input[ii + 2] << 16) | (input[ii + 1] << 8) | input[ii];
+				update[i] = (input[ii + 3] << 24) | (input[ii + 2] << 16) | (input[ii + 1] << 8) | input[ii];
 			}
 
 			// Transform
-			MD5Transform(buf, in);
-			
+			MD5Transform(buf, update);
+
 			mdi = 0;
 		}
 	}
@@ -345,8 +345,8 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 	mdi = (x[0] >>> 3) & 0x3F;
 
 	len = (mdi < 56) ? (56 - mdi) : (120 - mdi);
-	in[14] = x[0];
-	in[15] = x[1];
+	update[14] = x[0];
+	update[15] = x[1];
 
 	mdi = (x[0] >>> 3) & 0x3F;
 
@@ -362,16 +362,16 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 		input[mdi] = padding[c];
 		mdi += 1;
 		c += 1;
-		
+
 		if (mdi == 0x40) {
 
 			for (i = 0, ii = 0; i < 16; ++i, ii += 4) {
-				in[i] = (input[ii + 3] << 24) | (input[ii + 2] << 16) | (input[ii + 1] << 8) | input[ii];
+				update[i] = (input[ii + 3] << 24) | (input[ii + 2] << 16) | (input[ii + 1] << 8) | input[ii];
 			}
 
 			// Transform
-			MD5Transform(buf, in);
-			
+			MD5Transform(buf, update);
+
 			mdi = 0;
 		}
 	}
@@ -423,80 +423,80 @@ static stock MD5Transform_II(&a, &b, &c, &d, x, s, ac)
 	a += b;
 }
 
-static stock MD5Transform(buf[], in[])
+static stock MD5Transform(buf[], input[])
 {
 	new a = buf[0];
 	new b = buf[1];
 	new c = buf[2];
 	new d = buf[3];
 
-	MD5Transform_FF(a, b, c, d, in[0], 7, 0xd76aa478);
-	MD5Transform_FF(d, a, b, c, in[1], 12, 0xe8c7b756);
-	MD5Transform_FF(c, d, a, b, in[2], 17, 0x242070db);
-	MD5Transform_FF(b, c, d, a, in[3], 22, 0xc1bdceee);
-	MD5Transform_FF(a, b, c, d, in[4], 7, 0xf57c0faf);
-	MD5Transform_FF(d, a, b, c, in[5], 12, 0x4787c62a);
-	MD5Transform_FF(c, d, a, b, in[6], 17, 0xa8304613);
-	MD5Transform_FF(b, c, d, a, in[7], 22, 0xfd469501);
-	MD5Transform_FF(a, b, c, d, in[8], 7, 0x698098d8);
-	MD5Transform_FF(d, a, b, c, in[9], 12, 0x8b44f7af);
-	MD5Transform_FF(c, d, a, b, in[10], 17, 0xffff5bb1);
-	MD5Transform_FF(b, c, d, a, in[11], 22, 0x895cd7be);
-	MD5Transform_FF(a, b, c, d, in[12], 7, 0x6b901122);
-	MD5Transform_FF(d, a, b, c, in[13], 12, 0xfd987193);
-	MD5Transform_FF(c, d, a, b, in[14], 17, 0xa679438e);
-	MD5Transform_FF(b, c, d, a, in[15], 22, 0x49b40821);
+	MD5Transform_FF(a, b, c, d, input[0], 7, 0xd76aa478);
+	MD5Transform_FF(d, a, b, c, input[1], 12, 0xe8c7b756);
+	MD5Transform_FF(c, d, a, b, input[2], 17, 0x242070db);
+	MD5Transform_FF(b, c, d, a, input[3], 22, 0xc1bdceee);
+	MD5Transform_FF(a, b, c, d, input[4], 7, 0xf57c0faf);
+	MD5Transform_FF(d, a, b, c, input[5], 12, 0x4787c62a);
+	MD5Transform_FF(c, d, a, b, input[6], 17, 0xa8304613);
+	MD5Transform_FF(b, c, d, a, input[7], 22, 0xfd469501);
+	MD5Transform_FF(a, b, c, d, input[8], 7, 0x698098d8);
+	MD5Transform_FF(d, a, b, c, input[9], 12, 0x8b44f7af);
+	MD5Transform_FF(c, d, a, b, input[10], 17, 0xffff5bb1);
+	MD5Transform_FF(b, c, d, a, input[11], 22, 0x895cd7be);
+	MD5Transform_FF(a, b, c, d, input[12], 7, 0x6b901122);
+	MD5Transform_FF(d, a, b, c, input[13], 12, 0xfd987193);
+	MD5Transform_FF(c, d, a, b, input[14], 17, 0xa679438e);
+	MD5Transform_FF(b, c, d, a, input[15], 22, 0x49b40821);
 
-	MD5Transform_GG(a, b, c, d, in[1], 5, 0xf61e2562);
-	MD5Transform_GG(d, a, b, c, in[6], 9, 0xc040b340);
-	MD5Transform_GG(c, d, a, b, in[11], 14, 0x265e5a51);
-	MD5Transform_GG(b, c, d, a, in[0], 20, 0xe9b6c7aa);
-	MD5Transform_GG(a, b, c, d, in[5], 5, 0xd62f105d);
-	MD5Transform_GG(d, a, b, c, in[10], 9, 0x02441453);
-	MD5Transform_GG(c, d, a, b, in[15], 14, 0xd8a1e681);
-	MD5Transform_GG(b, c, d, a, in[4], 20, 0xe7d3fbc8);
-	MD5Transform_GG(a, b, c, d, in[9], 5, 0x21e1cde6);
-	MD5Transform_GG(d, a, b, c, in[14], 9, 0xc33707d6);
-	MD5Transform_GG(c, d, a, b, in[3], 14, 0xf4d50d87);
-	MD5Transform_GG(b, c, d, a, in[8], 20, 0x455a14ed);
-	MD5Transform_GG(a, b, c, d, in[13], 5, 0xa9e3e905);
-	MD5Transform_GG(d, a, b, c, in[2], 9, 0xfcefa3f8);
-	MD5Transform_GG(c, d, a, b, in[7], 14, 0x676f02d9);
-	MD5Transform_GG(b, c, d, a, in[12], 20, 0x8d2a4c8a);
+	MD5Transform_GG(a, b, c, d, input[1], 5, 0xf61e2562);
+	MD5Transform_GG(d, a, b, c, input[6], 9, 0xc040b340);
+	MD5Transform_GG(c, d, a, b, input[11], 14, 0x265e5a51);
+	MD5Transform_GG(b, c, d, a, input[0], 20, 0xe9b6c7aa);
+	MD5Transform_GG(a, b, c, d, input[5], 5, 0xd62f105d);
+	MD5Transform_GG(d, a, b, c, input[10], 9, 0x02441453);
+	MD5Transform_GG(c, d, a, b, input[15], 14, 0xd8a1e681);
+	MD5Transform_GG(b, c, d, a, input[4], 20, 0xe7d3fbc8);
+	MD5Transform_GG(a, b, c, d, input[9], 5, 0x21e1cde6);
+	MD5Transform_GG(d, a, b, c, input[14], 9, 0xc33707d6);
+	MD5Transform_GG(c, d, a, b, input[3], 14, 0xf4d50d87);
+	MD5Transform_GG(b, c, d, a, input[8], 20, 0x455a14ed);
+	MD5Transform_GG(a, b, c, d, input[13], 5, 0xa9e3e905);
+	MD5Transform_GG(d, a, b, c, input[2], 9, 0xfcefa3f8);
+	MD5Transform_GG(c, d, a, b, input[7], 14, 0x676f02d9);
+	MD5Transform_GG(b, c, d, a, input[12], 20, 0x8d2a4c8a);
 
-	MD5Transform_HH(a, b, c, d, in[5], 4, 0xfffa3942);
-	MD5Transform_HH(d, a, b, c, in[8], 11, 0x8771f681);
-	MD5Transform_HH(c, d, a, b, in[11], 16, 0x6d9d6122);
-	MD5Transform_HH(b, c, d, a, in[14], 23, 0xfde5380c);
-	MD5Transform_HH(a, b, c, d, in[1], 4, 0xa4beea44);
-	MD5Transform_HH(d, a, b, c, in[4], 11, 0x4bdecfa9);
-	MD5Transform_HH(c, d, a, b, in[7], 16, 0xf6bb4b60);
-	MD5Transform_HH(b, c, d, a, in[10], 23, 0xbebfbc70);
-	MD5Transform_HH(a, b, c, d, in[13], 4, 0x289b7ec6);
-	MD5Transform_HH(d, a, b, c, in[0], 11, 0xeaa127fa);
-	MD5Transform_HH(c, d, a, b, in[3], 16, 0xd4ef3085);
-	MD5Transform_HH(b, c, d, a, in[6], 23, 0x04881d05);
-	MD5Transform_HH(a, b, c, d, in[9], 4, 0xd9d4d039);
-	MD5Transform_HH(d, a, b, c, in[12], 11, 0xe6db99e5);
-	MD5Transform_HH(c, d, a, b, in[15], 16, 0x1fa27cf8);
-	MD5Transform_HH(b, c, d, a, in[2], 23, 0xc4ac5665);
+	MD5Transform_HH(a, b, c, d, input[5], 4, 0xfffa3942);
+	MD5Transform_HH(d, a, b, c, input[8], 11, 0x8771f681);
+	MD5Transform_HH(c, d, a, b, input[11], 16, 0x6d9d6122);
+	MD5Transform_HH(b, c, d, a, input[14], 23, 0xfde5380c);
+	MD5Transform_HH(a, b, c, d, input[1], 4, 0xa4beea44);
+	MD5Transform_HH(d, a, b, c, input[4], 11, 0x4bdecfa9);
+	MD5Transform_HH(c, d, a, b, input[7], 16, 0xf6bb4b60);
+	MD5Transform_HH(b, c, d, a, input[10], 23, 0xbebfbc70);
+	MD5Transform_HH(a, b, c, d, input[13], 4, 0x289b7ec6);
+	MD5Transform_HH(d, a, b, c, input[0], 11, 0xeaa127fa);
+	MD5Transform_HH(c, d, a, b, input[3], 16, 0xd4ef3085);
+	MD5Transform_HH(b, c, d, a, input[6], 23, 0x04881d05);
+	MD5Transform_HH(a, b, c, d, input[9], 4, 0xd9d4d039);
+	MD5Transform_HH(d, a, b, c, input[12], 11, 0xe6db99e5);
+	MD5Transform_HH(c, d, a, b, input[15], 16, 0x1fa27cf8);
+	MD5Transform_HH(b, c, d, a, input[2], 23, 0xc4ac5665);
 
-	MD5Transform_II(a, b, c, d, in[0], 6, 0xf4292244);
-	MD5Transform_II(d, a, b, c, in[7], 10, 0x432aff97);
-	MD5Transform_II(c, d, a, b, in[14], 15, 0xab9423a7);
-	MD5Transform_II(b, c, d, a, in[5], 21, 0xfc93a039);
-	MD5Transform_II(a, b, c, d, in[12], 6, 0x655b59c3);
-	MD5Transform_II(d, a, b, c, in[3], 10, 0x8f0ccc92);
-	MD5Transform_II(c, d, a, b, in[10], 15, 0xffeff47d);
-	MD5Transform_II(b, c, d, a, in[1], 21, 0x85845dd1);
-	MD5Transform_II(a, b, c, d, in[8], 6, 0x6fa87e4f);
-	MD5Transform_II(d, a, b, c, in[15], 10, 0xfe2ce6e0);
-	MD5Transform_II(c, d, a, b, in[6], 15, 0xa3014314);
-	MD5Transform_II(b, c, d, a, in[13], 21, 0x4e0811a1);
-	MD5Transform_II(a, b, c, d, in[4], 6, 0xf7537e82);
-	MD5Transform_II(d, a, b, c, in[11], 10, 0xbd3af235);
-	MD5Transform_II(c, d, a, b, in[2], 15, 0x2ad7d2bb);
-	MD5Transform_II(b, c, d, a, in[9], 21, 0xeb86d391);
+	MD5Transform_II(a, b, c, d, input[0], 6, 0xf4292244);
+	MD5Transform_II(d, a, b, c, input[7], 10, 0x432aff97);
+	MD5Transform_II(c, d, a, b, input[14], 15, 0xab9423a7);
+	MD5Transform_II(b, c, d, a, input[5], 21, 0xfc93a039);
+	MD5Transform_II(a, b, c, d, input[12], 6, 0x655b59c3);
+	MD5Transform_II(d, a, b, c, input[3], 10, 0x8f0ccc92);
+	MD5Transform_II(c, d, a, b, input[10], 15, 0xffeff47d);
+	MD5Transform_II(b, c, d, a, input[1], 21, 0x85845dd1);
+	MD5Transform_II(a, b, c, d, input[8], 6, 0x6fa87e4f);
+	MD5Transform_II(d, a, b, c, input[15], 10, 0xfe2ce6e0);
+	MD5Transform_II(c, d, a, b, input[6], 15, 0xa3014314);
+	MD5Transform_II(b, c, d, a, input[13], 21, 0x4e0811a1);
+	MD5Transform_II(a, b, c, d, input[4], 6, 0xf7537e82);
+	MD5Transform_II(d, a, b, c, input[11], 10, 0xbd3af235);
+	MD5Transform_II(c, d, a, b, input[2], 15, 0x2ad7d2bb);
+	MD5Transform_II(b, c, d, a, input[9], 21, 0xeb86d391);
 
 	buf[0] += a;
 	buf[1] += b;
@@ -509,7 +509,7 @@ static stock MD5Transform(buf[], in[])
  * RC4 Encoding Functions
  * All Credits go to SirLamer and Raydan
  * Taken from http://forums.alliedmods.net/showthread.php?t=101834
- * 
+ *
  ***********************************************************************************/
 
 /*

--- a/scripting/tests/test_compile-all.sp
+++ b/scripting/tests/test_compile-all.sp
@@ -66,7 +66,7 @@ public OnPluginStart() {
 	new arr[1], String:arr_str[1][1], arr_4[4];
 	decl Float:vec[3];
 	decl String:buf[1], String:twoDimStrArr[1][1];
-	new var;
+	new variable;
 	new Handle:handle;
 
 	// File: arrays.inc
@@ -155,7 +155,7 @@ public OnPluginStart() {
 	Client_SetWeaponPlayerAmmo(0, "");
 	Client_SetWeaponPlayerAmmoEx(0, 0);
 	Client_SetWeaponAmmo(0, "");
-	Client_GetNextWeapon(0, var);
+	Client_GetNextWeapon(0, variable);
 	Client_PrintHintText(0, "");
 	Client_PrintHintTextToAll("");
 	Client_PrintKeyHintText(0, "");
@@ -449,7 +449,7 @@ public OnPluginStart() {
 	// File: teams.inc
 	Team_HaveAllPlayers();
 	Team_GetClientCount(0);
-	Team_GetClientCounts(var, var);
+	Team_GetClientCounts(variable, variable);
 	Team_GetName(0, buf, sizeof(buf));
 	Team_SetName(0, "");
 	Team_GetScore(0);


### PR DESCRIPTION
Some keywords have been marked as reserved and error or give warnings for the 1.7 transitional syntax now. See https://forums.alliedmods.net/showpost.php?p=2233252&postcount=220

This fixes those. I wasn't really sure what to rename `in` inside the crypt.inc file since I really have no idea what's going on in there.

There's still a deprecated function warning:
`clients.inc(162) : warning 234: symbol "GetClientAuthString" is marked as deprecated: Use GetClientAuthId`

but that's a separate issue, and the only way to resolve it (I think) would be to use a macro if version >= 1.7 to use the new native. (or break pre-1.7 compatibility, but that's obviously not happening) 
