### PR TITLE
Add New Declarations till 1.10-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: c
 
 env:
-    - SMVERSION=1.6
     - SMVERSION=1.7
     - SMVERSION=1.8
+    - SMVERSION=1.9
+    - SMVERSION=1.10
 
 matrix:
     fast_finish: true
     allow_failures:
         - env: SMVERSION=1.7
-        - env: SMVERSION=1.8
 
 before_install:
     - sudo apt-get update

--- a/scripting/include/smlib/arrays.inc
+++ b/scripting/include/smlib/arrays.inc
@@ -15,13 +15,13 @@
  * @param start			Optional: Offset where to start (0 - (size-1)).
  * @return				Array index, or -1 if the value couldn't be found.
  */
-stock Array_FindValue(any:array[], size, any:value, start=0)
+stock int Array_FindValue(any[] array, int size, any value, int start=0)
 {
 	if (start < 0) {
 		start = 0;
 	}
 
-	for (new i=start; i < size; i++) {
+	for (int i=start; i < size; i++) {
 
 		if (array[i] == value) {
 			return i;
@@ -41,13 +41,13 @@ stock Array_FindValue(any:array[], size, any:value, start=0)
  * @param start			Optional: Offset where to start(0 - (size-1)).
  * @return				Array index, or -1 if the value couldn't be found.
  */
-stock Array_FindString(const String:array[][], size, const String:str[], bool:caseSensitive=true, start=0)
+stock int Array_FindString(const char[][] array, int size, const char[] str, bool caseSensitive=true, int start=0)
 {
 	if (start < 0) {
 		start = 0;
 	}
 
-	for (new i=start; i < size; i++) {
+	for (int i=start; i < size; i++) {
 
 		if (StrEqual(array[i], str, caseSensitive)) {
 			return i;
@@ -65,17 +65,17 @@ stock Array_FindString(const String:array[][], size, const String:str[], bool:ca
  * @param start			Optional: Offset where to start (0 - (size-1)).
  * @return				Array index.
  */
-stock Array_FindLowestValue(any:array[], size, start=0)
+stock int Array_FindLowestValue(any[] array, int size, int start=0)
 {
 	if (start < 0) {
 		start = 0;
 	}
 
-	new any:value = array[start];
-	new any:tempValue;
-	new x = start;
+	any value = array[start];
+	any tempValue;
+	int x = start;
 
-	for (new i=start; i < size; i++) {
+	for (int i=start; i < size; i++) {
 
 		tempValue = array[i];
 
@@ -97,17 +97,17 @@ stock Array_FindLowestValue(any:array[], size, start=0)
  * @param start			Optional: Offset where to start (0 - (size-1)).
  * @return				Array index.
  */
-stock Array_FindHighestValue(any:array[], size, start=0)
+stock int Array_FindHighestValue(any[] array, int size, int start=0)
 {
 	if (start < 0) {
 		start = 0;
 	}
 
-	new any:value = array[start];
-	new any:tempValue;
-	new x = start;
+	any value = array[start];
+	any tempValue;
+	int x = start;
 
-	for (new i=start; i < size; i++) {
+	for (int i=start; i < size; i++) {
 
 		tempValue = array[i];
 
@@ -131,13 +131,13 @@ stock Array_FindHighestValue(any:array[], size, start=0)
  * @param start			Optional: Offset where to start (0 - (size-1)).
  * @noreturn
  */
-stock Array_Fill(any:array[], size, any:value, start=0)
+stock void Array_Fill(any[] array, int size, any value, int start=0)
 {
 	if (start < 0) {
 		start = 0;
 	}
 
-	for (new i=start; i < size; i++) {
+	for (int i=start; i < size; i++) {
 		array[i] = value;
 	}
 }
@@ -150,9 +150,9 @@ stock Array_Fill(any:array[], size, any:value, start=0)
  * @param size			Size of the array (or number of cells to copy)
  * @noreturn
  */
-stock Array_Copy(const any:array[], any:newArray[], size)
+stock void Array_Copy(const any[] array, any[] newArray, int size)
 {
-	for (new i=0; i < size; i++) {
+	for (int i=0; i < size; i++) {
 		newArray[i] = array[i];
 	}
 }

--- a/scripting/include/smlib/clients.inc
+++ b/scripting/include/smlib/clients.inc
@@ -43,7 +43,7 @@
  * @param 1		Name of the client index variable (will be only valid in the loop).
  * @param 2		CLIENTFILTER_ flags to check.
  */
-#define LOOP_CLIENTS(%1,%2) for (new %1=Client_GetNext(%2); %1 >= 1 && %1 <= MaxClients; %1=Client_GetNext(%2, ++%1))
+#define LOOP_CLIENTS(%1,%2) for (int %1=Client_GetNext(%2); %1 >= 1 && %1 <= MaxClients; %1=Client_GetNext(%2, ++%1))
 
 /**
  * Macro for iterating trough all observers of a player.
@@ -52,7 +52,7 @@
  * @param 2		Name of the observer client index variable (will be only valid in the loop).
  * @param 3		CLIENTFILTER_ flags to check.
  */
-#define LOOP_OBSERVERS(%1,%2,%3) for (new %2=Client_GetNextObserver(%1, 1, %3); %2 >= 1 && %2 <= MaxClients; %2=Client_GetNextObserver(%1, ++%2, %3))
+#define LOOP_OBSERVERS(%1,%2,%3) for (int %2=Client_GetNextObserver(%1, 1, %3); %2 >= 1 && %2 <= MaxClients; %2=Client_GetNextObserver(%1, ++%2, %3))
 
 /**
  * Very useful macro to iterate all weapons of a client.
@@ -84,7 +84,7 @@
 * @param flags		Flag to set, use one of the HIDEHUD_ hiding constants
 * @noreturn
 */
-stock Client_SetHideHud(client, flags)
+stock void Client_SetHideHud(int client, int flags)
 {
 	SetEntProp(client, Prop_Send, "m_iHideHUD", flags);
 }
@@ -96,7 +96,7 @@ stock Client_SetHideHud(client, flags)
 * @param checkConnected		Set to false to skip the IsClientConnected check
 * @return					Returns true if the specified entity index is a player connected, false otherwise.
 */
-stock bool:Client_IsValid(client, bool:checkConnected=true)
+stock bool Client_IsValid(int client, bool checkConnected=true)
 {
 	if (client > 4096) {
 		client = EntRefToEntIndex(client);
@@ -119,7 +119,7 @@ stock bool:Client_IsValid(client, bool:checkConnected=true)
 * @param entity		An entity index.
 * @return			Returns true if the specified index is a player and ingame, false otherwise.
 */
-stock bool:Client_IsIngame(client)
+stock bool Client_IsIngame(int client)
 {
 	if (!Client_IsValid(client, false)) {
 		return false;
@@ -134,7 +134,7 @@ stock bool:Client_IsIngame(client)
 * @param entity		An entity index.
 * @return			Returns true if the specified index is a player, ingame and authed, false otherwise.
 */
-stock bool:Client_IsIngameAuthorized(client)
+stock bool Client_IsIngameAuthorized(int client)
 {
 	if (!Client_IsIngame(client)) {
 		return false;
@@ -149,17 +149,18 @@ stock bool:Client_IsIngameAuthorized(client)
 * Finds a player by his SteamID
 *
 * @param auth			SteamID to search for
+* @param authIDtype		Type of AuthID
 * @return				Client Index or -1
 */
-stock Client_FindBySteamId(const String:auth[])
+stock int Client_FindBySteamId(const char[] auth, AuthIdType authType=AuthId_Steam2)
 {
-	new String:clientAuth[MAX_STEAMAUTH_LENGTH];
-	for (new client=1; client <= MaxClients; client++) {
+	char clientAuth[MAX_STEAMAUTH_LENGTH];
+	for (int client=1; client <= MaxClients; client++) {
 		if (!IsClientAuthorized(client)) {
 			continue;
 		}
 
-		GetClientAuthId(client, AuthId_Steam2, clientAuth, sizeof(clientAuth));
+		GetClientAuthId(client, authType, clientAuth, sizeof(clientAuth));
 
 		if (StrEqual(auth, clientAuth)) {
 			return client;
@@ -178,10 +179,10 @@ stock Client_FindBySteamId(const String:auth[])
 * @param caseSensitive	If true, comparison is case sensitive. If false (default), comparison is case insensitive.
 * @return				Client Index or -1
 */
-stock Client_FindByName(const String:name[], bool:partOfName=true, bool:caseSensitive=false)
+stock int Client_FindByName(const char[] name, bool partOfName=true, bool caseSensitive=false)
 {
-	new String:clientName[MAX_NAME_LENGTH];
-	for (new client=1; client <= MaxClients; client++) {
+	char clientName[MAX_STEAMAUTH_LENGTH];
+	for (int client=1; client <= MaxClients; client++) {
 		if (!IsClientAuthorized(client)) {
 			continue;
 		}
@@ -231,9 +232,9 @@ enum Obs_Allow
  * @param client		Client Index.
  * @return				The current observer mode (ObsMode).
  */
-stock Obs_Mode:Client_GetObserverMode(client)
+stock Obs_Mode Client_GetObserverMode(int client)
 {
-	return Obs_Mode:GetEntProp(client, Prop_Send, "m_iObserverMode");
+	return view_as<Obs_Mode>(GetEntProp(client, Prop_Send, "m_iObserverMode"));
 }
 
 
@@ -247,7 +248,7 @@ stock Obs_Mode:Client_GetObserverMode(client)
  * @param updateMoveType	Set to true (default) to allow this function updating the movetype, false otherwise.
  * @noreturn
  */
-stock bool:Client_SetObserverMode(client, Obs_Mode:mode, bool:updateMoveType=true)
+stock bool Client_SetObserverMode(int client, Obs_Mode mode, bool updateMoveType=true)
 {
 	if (mode < OBS_MODE_NONE || mode >= NUM_OBSERVER_MODES) {
 		return false;
@@ -256,10 +257,10 @@ stock bool:Client_SetObserverMode(client, Obs_Mode:mode, bool:updateMoveType=tru
 	// check mp_forcecamera settings for dead players
 	if (mode > OBS_MODE_FIXED && GetClientTeam(client) > TEAM_SPECTATOR)
 	{
-		new Handle:mp_forcecamera = FindConVar("mp_forcecamera");
+		ConVar mp_forcecamera = FindConVar("mp_forcecamera");
 
-		if (mp_forcecamera != INVALID_HANDLE) {
-			switch (GetConVarInt(mp_forcecamera))
+		if (mp_forcecamera != null) {
+			switch (mp_forcecamera.IntValue)
 			{
 				case OBS_ALLOW_TEAM: {
 					mode = OBS_MODE_IN_EYE;
@@ -271,13 +272,13 @@ stock bool:Client_SetObserverMode(client, Obs_Mode:mode, bool:updateMoveType=tru
 		}
 	}
 
-	new Obs_Mode:observerMode = Client_GetObserverMode(client);
+	Obs_Mode observerMode = Client_GetObserverMode(client);
 	if (observerMode > OBS_MODE_DEATHCAM) {
 		// remember mode if we were really spectating before
 		Client_SetObserverLastMode(client, observerMode);
 	}
 
-	SetEntProp(client, Prop_Send, "m_iObserverMode", _:mode);
+	SetEntProp(client, Prop_Send, "m_iObserverMode", view_as<int>(mode));
 
 	switch (mode) {
 		case OBS_MODE_NONE, OBS_MODE_FIXED, OBS_MODE_DEATHCAM: {
@@ -314,9 +315,9 @@ stock bool:Client_SetObserverMode(client, Obs_Mode:mode, bool:updateMoveType=tru
  * @param client		Client Index.
  * @return				Last Observer mode
  */
-stock Obs_Mode:Client_GetObserverLastMode(client)
+stock Obs_Mode Client_GetObserverLastMode(int client)
 {
-	return Obs_Mode:GetEntProp(client, Prop_Data, "m_iObserverLastMode");
+	return view_as<Obs_Mode>(GetEntProp(client, Prop_Data, "m_iObserverLastMode"));
 }
 
 /**
@@ -326,9 +327,9 @@ stock Obs_Mode:Client_GetObserverLastMode(client)
  * @param mode			Last Observer mode
  * @noreturn
  */
-stock Client_SetObserverLastMode(client, Obs_Mode:mode)
+stock void Client_SetObserverLastMode(int client, Obs_Mode mode)
 {
-	SetEntProp(client, Prop_Data, "m_iObserverLastMode", _:mode);
+	SetEntProp(client, Prop_Data, "m_iObserverLastMode", view_as<int>(mode));
 }
 
 /**
@@ -339,7 +340,7 @@ stock Client_SetObserverLastMode(client, Obs_Mode:mode)
  * @param vec			Vector Buffer.
  * @noreturn
  */
-stock Client_GetViewOffset(client, Float:vec[3])
+stock void Client_GetViewOffset(int client, float vec[3])
 {
 	GetEntPropVector(client, Prop_Data, "m_vecViewOffset", vec);
 }
@@ -352,7 +353,7 @@ stock Client_GetViewOffset(client, Float:vec[3])
  * @param vec			Vector buffer.
  * @noreturn
  */
-stock Client_SetViewOffset(client, Float:vec[3])
+stock void Client_SetViewOffset(int client, float vec[3])
 {
 	SetEntPropVector(client, Prop_Data, "m_vecViewOffset", vec);
 }
@@ -363,7 +364,7 @@ stock Client_SetViewOffset(client, Float:vec[3])
  * @param client		Client Index.
  * @return				Observed Entity Index.
  */
-stock Client_GetObserverTarget(client)
+stock int Client_GetObserverTarget(int client)
 {
 	return GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
 }
@@ -376,7 +377,7 @@ stock Client_GetObserverTarget(client)
  * @param resetFOV		If to reset the client's field of view.
  * @noreturn
  */
-stock Client_SetObserverTarget(client, entity, bool:resetFOV=true)
+stock void Client_SetObserverTarget(int client, int entity, bool resetFOV=true)
 {
 	SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", entity);
 
@@ -391,7 +392,7 @@ stock Client_SetObserverTarget(client, entity, bool:resetFOV=true)
  * @param client		Client Index.
  * @return				Field Of View
  */
-stock Client_GetFOV(client)
+stock int Client_GetFOV(int client)
 {
 	return GetEntProp(client, Prop_Send, "m_iFOV");
 }
@@ -403,7 +404,7 @@ stock Client_GetFOV(client)
  * @param value			Field Of View
  * @noreturn
  */
-stock Client_SetFOV(client, value)
+stock void Client_SetFOV(int client, int value)
 {
 	SetEntProp(client, Prop_Send, "m_iFOV", value);
 }
@@ -414,9 +415,9 @@ stock Client_SetFOV(client, value)
  * @param client		Client Index.
  * @return				True if the viewmodel is drawn, false otherwise.
  */
-stock bool:Client_DrawViewModel(client)
+stock bool Client_DrawViewModel(int client)
 {
-	return bool:GetEntProp(client, Prop_Send, "m_bDrawViewmodel");
+	return view_as<bool>(GetEntProp(client, Prop_Send, "m_bDrawViewmodel"));
 }
 
 /**
@@ -426,7 +427,7 @@ stock bool:Client_DrawViewModel(client)
  * @param drawViewModel	Set to true if to draw, false otherwise.
  * @noreturn
  */
-stock Client_SetDrawViewModel(client, bool:drawViewModel)
+stock void Client_SetDrawViewModel(int client, bool drawViewModel)
 {
 	SetEntProp(client, Prop_Send, "m_bDrawViewmodel", drawViewModel);
 }
@@ -441,7 +442,7 @@ stock Client_SetDrawViewModel(client, bool:drawViewModel)
  * 						if false the client will be put in firstperson mode.
  * @noreturn
  */
-stock Client_SetThirdPersonMode(client, enable=true)
+stock void Client_SetThirdPersonMode(int client, bool enable=true)
 {
 	if (enable) {
 		Client_SetObserverTarget(client, 0);
@@ -463,9 +464,9 @@ stock Client_SetThirdPersonMode(client, enable=true)
  * @param client	Cient Undex
  * @return			true if the client is currently in thirdperson mode, false otherwise
  */
-stock Client_IsInThirdPersonMode(client)
+stock bool Client_IsInThirdPersonMode(int client)
 {
-	return GetEntProp(client, Prop_Data, "m_iObserverMode");
+	return view_as<bool>(GetEntProp(client, Prop_Data, "m_iObserverMode"));
 }
 
 #define FFADE_IN			0x0001		// Just here so we don't pass 0 into the function
@@ -488,36 +489,41 @@ stock Client_IsInThirdPersonMode(client)
  * @param a				transparency
  * @return				True on success, false otherwise
  */
-stock bool:Client_ScreenFade(client, duration, mode, holdtime=-1, r=0, g=0, b=0, a=255, bool:reliable=true)
+stock bool Client_ScreenFade(int client, int duration, int mode, int holdtime=-1, int r=0, int g=0, int b=0, int a=255, bool reliable=true)
 {
-	new Handle:userMessage = StartMessageOne("Fade", client, (reliable?USERMSG_RELIABLE:0));
+	Handle userMessage = StartMessageOne("Fade", client, (reliable?USERMSG_RELIABLE:0));
 
-	if (userMessage == INVALID_HANDLE) {
+	if (userMessage == null) {
 		return false;
 	}
 
 	if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available &&
 		GetUserMessageType() == UM_Protobuf) {
 
-		new color[4];
+		Protobuf message = UserMessageToProtobuf(userMessage);
+
+		int color[4];
 		color[0] = r;
 		color[1] = g;
 		color[2] = b;
 		color[3] = a;
 
-		PbSetInt(userMessage,   "duration",   duration);
-		PbSetInt(userMessage,   "hold_time",  holdtime);
-		PbSetInt(userMessage,   "flags",      mode);
-		PbSetColor(userMessage, "clr",        color);
+		message.SetInt("duration",   duration);
+		message.SetInt("hold_time",  holdtime);
+		message.SetInt("flags",      mode);
+		message.SetColor("clr",        color);
 	}
 	else {
-		BfWriteShort(userMessage,	duration);	// Fade duration
-		BfWriteShort(userMessage,	holdtime);	// Fade hold time
-		BfWriteShort(userMessage,	mode);		// What to do
-		BfWriteByte(userMessage,	r);			// Color R
-		BfWriteByte(userMessage,	g);			// Color G
-		BfWriteByte(userMessage,	b);			// Color B
-		BfWriteByte(userMessage,	a);			// Color Alpha
+
+		BfWrite message = UserMessageToBfWrite(userMessage);
+
+		message.WriteShort(duration);	// Fade duration
+		message.WriteShort(holdtime);	// Fade hold time
+		message.WriteShort(mode);		// What to do
+		message.WriteByte(r);			// Color R
+		message.WriteByte(g);			// Color G
+		message.WriteByte(b);			// Color B
+		message.WriteByte(a);			// Color Alpha
 	}
 	EndMessage();
 
@@ -532,14 +538,14 @@ stock bool:Client_ScreenFade(client, duration, mode, holdtime=-1, r=0, g=0, b=0,
  * @param closelist		An array that holds all clones of a client.
  * @return				Returns how many clones a client has.
  */
-stock Client_GetClones(client, cloneList[])
+stock int Client_GetClones(int client, int[] cloneList)
 {
-	new x=0;
-	decl String:ip_client[16], String:ip_player[16];
+	int x=0;
+	char ip_client[16], ip_player[16];
 
 	GetClientIP(client, ip_client, sizeof(client));
 
-	for (new player=1; player <= MaxClients; player++) {
+	for (int player=1; player <= MaxClients; player++) {
 
 		if (IsClientInGame(player)) {
 			GetClientIP(player, ip_player, sizeof(ip_player));
@@ -559,16 +565,9 @@ stock Client_GetClones(client, cloneList[])
  * @param client		Client index.
  * @return				Returns true if the client is on a ladder other wise false.
  */
-stock bool:Client_IsOnLadder(client)
+stock bool Client_IsOnLadder(int client)
 {
-	new MoveType:movetype = GetEntityMoveType(client);
-
-	if (movetype == MOVETYPE_LADDER) {
-		return true;
-	}
-	else{
-		return false;
-	}
+	return view_as<MoveType>(GetEntityMoveType(client)) == MOVETYPE_LADDER;
 }
 
 enum Water_Level
@@ -585,9 +584,9 @@ enum Water_Level
  * @param client		Client index.
  * @return				Returns 0 if not in water. 1 if feets are in water. 2 if waist is in water. 3 if head is in water.
  */
-stock Water_Level:Client_GetWaterLevel(client)
+stock Water_Level Client_GetWaterLevel(int client)
 {
-	return Water_Level:GetEntProp(client, Prop_Send, "m_nWaterLevel");
+	return view_as<Water_Level>(GetEntProp(client, Prop_Send, "m_nWaterLevel"));
 }
 
 /*
@@ -596,7 +595,7 @@ stock Water_Level:Client_GetWaterLevel(client)
  * @param client		Client index.
  * @return				returns the actual power left in percent.
  */
-stock Float:Client_GetSuitSprintPower(client)
+stock float Client_GetSuitSprintPower(int client)
 {
 	return GetEntPropFloat(client, Prop_Send, "m_flSuitPower");
 }
@@ -608,7 +607,7 @@ stock Float:Client_GetSuitSprintPower(client)
  * @param power			power (0.0 to 100.0)
  * @noreturn
  */
-stock Client_SetSuitSprintPower(client, Float:power)
+stock void Client_SetSuitSprintPower(int client, float power)
 {
 	SetEntPropFloat(client, Prop_Send, "m_flSuitPower", power);
 }
@@ -620,11 +619,11 @@ stock Client_SetSuitSprintPower(client, Float:power)
  * @param countBots		If true bots will be counted too.
  * @return				Client count in the server.
  */
-stock Client_GetCount(bool:countInGameOnly=true, bool:countFakeClients=true)
+stock void Client_GetCount(bool countInGameOnly=true, bool countFakeClients=true)
 {
-	new numClients = 0;
+	int numClients = 0;
 
-	for (new client=1; client <= MaxClients; client++) {
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!IsClientConnected(client)) {
 			continue;
@@ -655,21 +654,21 @@ stock Client_GetCount(bool:countInGameOnly=true, bool:countFakeClients=true)
  * @param goldSource	If true, get the ping as displayed in the player's scoreboard, false returns the net_graph variant.
  * @return				Client's fake ping or 0 for fake clients
  */
-stock Client_GetFakePing(client, bool:goldSource=true)
+stock int Client_GetFakePing(int client, bool goldSource=true)
 {
 	if (IsFakeClient(client)) {
 		return 0;
 	}
 
-	new ping;
-	new Float:latency = GetClientLatency(client, NetFlow_Outgoing); // in seconds
+	int ping;
+	float latency = GetClientLatency(client, NetFlow_Outgoing); // in seconds
 
 	// that should be the correct latency, we assume that cmdrate is higher
 	// then updaterate, what is the case for default settings
-	decl String:cl_cmdrate[4];
+	char cl_cmdrate[4];
 	GetClientInfo(client, "cl_cmdrate", cl_cmdrate, sizeof(cl_cmdrate));
 
-	new Float:tickRate = GetTickInterval();
+	float tickRate = GetTickInterval();
 	latency -= (0.5 / StringToInt(cl_cmdrate)) + TICKS_TO_TIME(1.0); // correct latency
 
 	if (goldSource) {
@@ -690,7 +689,7 @@ stock Client_GetFakePing(client, bool:goldSource=true)
  * @param client		Client index
  * @return				The closest client or -1
  */
-stock Client_GetClosestToClient(client)
+stock int Client_GetClosestToClient(int client)
 {
 	return Edict_GetClosestToEdict(client, true);
 }
@@ -703,7 +702,7 @@ stock Client_GetClosestToClient(client)
  * @param size				Size of the String buffer
  * @noreturn
  */
-stock Client_GetLastPlaceName(client, String:buffer[], size)
+stock void Client_GetLastPlaceName(int client, char[] buffer, int size)
 {
 	GetEntPropString(client, Prop_Send, "m_szLastPlaceName", buffer, size);
 }
@@ -714,7 +713,7 @@ stock Client_GetLastPlaceName(client, String:buffer[], size)
  * @param client			Client's index.
  * @return					Score.
  */
-stock Client_GetScore(client)
+stock int Client_GetScore(int client)
 {
 	return GetClientFrags(client);
 }
@@ -726,7 +725,7 @@ stock Client_GetScore(client)
  * @param value				Score.
  * @noreturn
  */
-stock Client_SetScore(client, value)
+stock void Client_SetScore(int client, int value)
 {
 	SetEntProp(client, Prop_Data, "m_iFrags", value);
 }
@@ -737,7 +736,7 @@ stock Client_SetScore(client, value)
  * @param client			Client's index.
  * @return					Death count
  */
-stock Client_GetDeaths(client)
+stock int Client_GetDeaths(int client)
 {
 	return GetEntProp(client, Prop_Data, "m_iDeaths");
 }
@@ -749,7 +748,7 @@ stock Client_GetDeaths(client)
  * @param value				Death count
  * @noreturn
  */
-stock Client_SetDeaths(client, value)
+stock void Client_SetDeaths(int client, any value)
 {
 	SetEntProp(client, Prop_Data, "m_iDeaths", value);
 }
@@ -760,7 +759,7 @@ stock Client_SetDeaths(client, value)
  * @param client			Client's index.
  * @return					Armor value
  */
-stock Client_GetArmor(client)
+stock int Client_GetArmor(int client)
 {
 	return GetEntProp(client, Prop_Data, "m_ArmorValue");
 }
@@ -772,7 +771,7 @@ stock Client_GetArmor(client)
  * @param value				Armor value
  * @noreturn
  */
-stock Client_SetArmor(client, value)
+stock int Client_SetArmor(int client, any value)
 {
 	SetEntProp(client, Prop_Data, "m_ArmorValue", value);
 }
@@ -783,9 +782,9 @@ stock Client_SetArmor(client, value)
  * @param client			Client's index.
  * @return					Suitpower
  */
-stock Float:Client_GetSuitPower(client)
+stock float Client_GetSuitPower(int client)
 {
-	return Float:GetEntPropFloat(client, Prop_Data, "m_flSuitPower");
+	return GetEntPropFloat(client, Prop_Data, "m_flSuitPower");
 }
 
 /**
@@ -795,7 +794,7 @@ stock Float:Client_GetSuitPower(client)
  * @param value				Suitpower
  * @noreturn
  */
-stock Client_SetSuitPower(client, Float:value)
+stock void Client_SetSuitPower(int client, float value)
 {
 	SetEntPropFloat(client, Prop_Data, "m_flSuitPower", value);
 }
@@ -814,7 +813,7 @@ stock Client_SetSuitPower(client, Float:value)
  * @param client			Client's index.
  * @return					The active devices (bitwise value)
  */
-stock Client_GetActiveDevices(client)
+stock int Client_GetActiveDevices(int client)
 {
 	return GetEntProp(client, Prop_Send, "m_bitsActiveDevices");
 }
@@ -826,7 +825,7 @@ stock Client_GetActiveDevices(client)
  * @param client			Client's index.
  * @return					Next decal time
  */
-stock Float:Client_GetNextDecalTime(client)
+stock float Client_GetNextDecalTime(int client)
 {
 	return GetEntPropFloat(client, Prop_Data, "m_flNextDecalTime");
 }
@@ -837,7 +836,7 @@ stock Float:Client_GetNextDecalTime(client)
  * @param client			Client's index.
  * @return					True if he is allowed to spray a decal, false otherwise
  */
-stock bool:Client_CanSprayDecal(client)
+stock bool Client_CanSprayDecal(int client)
 {
 	return Client_GetNextDecalTime(client) <= GetGameTime();
 }
@@ -849,11 +848,9 @@ stock bool:Client_CanSprayDecal(client)
  * @param client			Client's index.
  * @return					Vehicle index, -1 if the client isn't in a vehicle.
  */
-stock Client_GetVehicle(client)
+stock int Client_GetVehicle(int client)
 {
-	new m_hVehicle = GetEntPropEnt(client, Prop_Send, "m_hVehicle");
-
-	return m_hVehicle;
+	return GetEntPropEnt(client, Prop_Send, "m_hVehicle");
 }
 
 /**
@@ -862,9 +859,9 @@ stock Client_GetVehicle(client)
  * @param client			Client's index.
  * @return					True if he is in a vehicle, false otherwise
  */
-stock bool:Client_IsInVehicle(client)
+stock bool Client_IsInVehicle(int client)
 {
-	return !(Client_GetVehicle(client) == -1);
+	return Client_GetVehicle(client) != -1;
 }
 
 /**
@@ -873,7 +870,7 @@ stock bool:Client_IsInVehicle(client)
  * @param client			Client's index.
  * @noreturn
  */
-stock Client_RemoveAllDecals(client)
+stock void Client_RemoveAllDecals(int client)
 {
 	ClientCommand(client, "r_cleardecals");
 }
@@ -884,9 +881,9 @@ stock Client_RemoveAllDecals(client)
  * @param vehicle			Client index.
  * @return					True on success, false otherwise.
  */
-stock bool:Client_ExitVehicle(client)
+stock bool Client_ExitVehicle(int client)
 {
-	new vehicle = Client_GetVehicle(client);
+	int vehicle = Client_GetVehicle(client);
 
 	if (vehicle == -1) {
 		return false;
@@ -907,11 +904,11 @@ stock bool:Client_ExitVehicle(client)
  * @param pitch			The pitch of the audiofile.
  * @return				True on success, false on failure.
  */
-stock bool:Client_RawAudio(client, const emitter, const String:soundfile[], Float:length = 0.0, pitch = 100)
+stock bool Client_RawAudio(int client, const int emitter, const char[] soundfile, float length = 0.0, int pitch = 100)
 {
-	new Handle:message = StartMessageOne("RawAudio", client);
+	Handle message = StartMessageOne("RawAudio", client);
 
-	if (message == INVALID_HANDLE) {
+	if (message == null) {
 		return false;
 	}
 
@@ -945,11 +942,11 @@ stock bool:Client_RawAudio(client, const emitter, const String:soundfile[], Floa
  * @param pitch			The pitch of the audiofile.
  * @return				True on success, false on failure.
  */
-stock bool:Client_RawAudioToAll(const emitter, const String:soundfile[], Float:length = 0.0, pitch = 100)
+stock bool Client_RawAudioToAll(const int emitter, const char[] soundfile, float length = 0.0, int pitch = 100)
 {
-	new Handle:message = StartMessageAll("RawAudio");
+	Handle message = StartMessageAll("RawAudio");
 
-	if (message == INVALID_HANDLE) {
+	if (message == null) {
 		return false;
 	}
 
@@ -978,9 +975,9 @@ stock bool:Client_RawAudioToAll(const emitter, const String:soundfile[], Float:l
  *
  * @param client		Client Index
  * @param value			The impulse command value.
- * @return				True on success, false on failure.
+ * @noreturn
  */
-stock Client_Impulse(client, value)
+stock void Client_Impulse(int client, int value)
 {
 	SetEntProp(client, Prop_Data, "m_nImpulse", value);
 }
@@ -992,9 +989,9 @@ stock Client_Impulse(client, value)
  * @param client		Client Index.
  * @return				Weapon list offset or -1 on failure.
  */
-stock Client_GetWeaponsOffset(client)
+stock int Client_GetWeaponsOffset(int client)
 {
-	static offset = -1;
+	static int offset = -1;
 
 	if (offset == -1) {
 		offset = FindDataMapInfo(client, "m_hMyWeapons");
@@ -1009,9 +1006,9 @@ stock Client_GetWeaponsOffset(client)
  * @param client		Client Index.
  * @return				Weapon Index or INVALID_ENT_REFERENCE if the client has no active weapon.
  */
-stock Client_GetActiveWeapon(client)
+stock int Client_GetActiveWeapon(int client)
 {
-	new weapon =  GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
+	int weapon =  GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
 
 	if (!Entity_IsValid(weapon)) {
 		return INVALID_ENT_REFERENCE;
@@ -1025,12 +1022,12 @@ stock Client_GetActiveWeapon(client)
  *
  * @param client		Client Index.
  * @param buffer		String Buffer to store the weapon's classname.
- * @param size			Max size of String: buffer.
- * @return				Weapon Entity Index on success or INVALID_ENT_REFERENCE otherwise
+ * @param size			Max size of char buffer.
+ * @return				Weapon Entity Index on success or INVALID_ENT_REFERENCE otherwise 
  */
-stock Client_GetActiveWeaponName(client, String:buffer[], size)
+stock int Client_GetActiveWeaponName(int client, char[] buffer, int size)
 {
-	new weapon = Client_GetActiveWeapon(client);
+	int weapon = Client_GetActiveWeapon(client);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		buffer[0] = '\0';
@@ -1050,7 +1047,7 @@ stock Client_GetActiveWeaponName(client, String:buffer[], size)
  * @param weapon		Index of a valid weapon.
  * @noreturn
  */
-stock Client_SetActiveWeapon(client, weapon)
+stock void Client_SetActiveWeapon(int client, int weapon)
 {
 	SetEntPropEnt(client, Prop_Data, "m_hActiveWeapon", weapon);
 	ChangeEdictState(client, FindDataMapInfo(client, "m_hActiveWeapon"));
@@ -1064,9 +1061,9 @@ stock Client_SetActiveWeapon(client, weapon)
  * @param className		Weapon Classname.
  * @return				True on success, false on failure.
  */
-stock bool:Client_ChangeWeapon(client, const String:className[])
+stock bool Client_ChangeWeapon(int client, const char[] className)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return false;
@@ -1086,9 +1083,9 @@ stock bool:Client_ChangeWeapon(client, const String:className[])
  * @param client 		Client Index.
  * @return				Entity Index or, INVALID_ENT_REFERENCE.
  */
-stock Client_ChangeToLastWeapon(client)
+stock int Client_ChangeToLastWeapon(int client)
 {
-	new weapon = Client_GetLastActiveWeapon(client);
+	int weapon = Client_GetLastActiveWeapon(client);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		weapon = Client_GetDefaultWeapon(client);
@@ -1113,9 +1110,9 @@ stock Client_ChangeToLastWeapon(client)
  * @param client		Client Index.
  * @return				Entity Index of the weapon on success, INVALID_ENT_REFERENCE on failure.
  */
-stock Client_GetLastActiveWeapon(client)
+stock int Client_GetLastActiveWeapon(int client)
 {
-	new weapon = GetEntPropEnt(client, Prop_Data, "m_hLastWeapon");
+	int weapon = GetEntPropEnt(client, Prop_Data, "m_hLastWeapon");
 
 	if (!Entity_IsValid(weapon)) {
 		return INVALID_ENT_REFERENCE;
@@ -1129,12 +1126,12 @@ stock Client_GetLastActiveWeapon(client)
  *
  * @param client		Client Index.
  * @param buffer		Buffer to store the weapon classname.
- * @param size			Max size of String: buffer.
+ * @param size			Max size of char buffer.
  * @return				True on success, false on failure.
  */
-stock bool:Client_GetLastActiveWeaponName(client, String:buffer[], size)
+stock bool Client_GetLastActiveWeaponName(int client, char[] buffer, int size)
 {
-	new weapon = Client_GetLastActiveWeapon(client);
+	int weapon = Client_GetLastActiveWeapon(client);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		buffer[0] = '\0';
@@ -1153,7 +1150,7 @@ stock bool:Client_GetLastActiveWeaponName(client, String:buffer[], size)
  * @param weapon		Entity Index of a weapon.
  * @noreturn
  */
-stock Client_SetLastActiveWeapon(client, weapon)
+stock void Client_SetLastActiveWeapon(int client, int weapon)
 {
 	SetEntPropEnt(client, Prop_Data, "m_hLastWeapon", weapon);
 	ChangeEdictState(client, FindDataMapInfo(client, "m_hLastWeapon"));
@@ -1167,7 +1164,7 @@ stock Client_SetLastActiveWeapon(client, weapon)
  * @param switchTo		If true, the client will switch to that weapon (make it active).
  * @noreturn
  */
-stock Client_EquipWeapon(client, weapon, bool:switchTo=false)
+stock void Client_EquipWeapon(int client, int weapon, bool switchTo=false)
 {
 	EquipPlayerWeapon(client, weapon);
 
@@ -1177,14 +1174,14 @@ stock Client_EquipWeapon(client, weapon, bool:switchTo=false)
 }
 
 /**
- * Savly detaches a clients weapon, to remove it as example.
+ * Safely detaches a clients weapon, to remove it as example.
  * The client will select his last weapon when detached.
  *
  * @param client 		Client Index.
  * @param weapon		Entity Index of the weapon, you'd like to detach.
  * @return				True on success, false otherwise.
  */
-stock bool:Client_DetachWeapon(client, weapon)
+stock bool Client_DetachWeapon(int client, int weapon)
 {
 	if (!RemovePlayerItem(client, weapon)) {
 		return false;
@@ -1205,9 +1202,9 @@ stock bool:Client_DetachWeapon(client, weapon)
  * @param switchTo		If set to true, the client will switch the active weapon to the new weapon.
  * @return				Entity Index of the given weapon on success, INVALID_ENT_REFERENCE on failure.
  */
-stock Client_GiveWeapon(client, const String:className[], bool:switchTo=true)
+stock int Client_GiveWeapon(int client, const char[] className, bool switchTo=true)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		weapon = Weapon_CreateForOwner(client, className);
@@ -1234,9 +1231,9 @@ stock Client_GiveWeapon(client, const String:className[], bool:switchTo=true)
  * @param secondaryClip	Secondary ammo value in the weapon clip, if -1 the value is untouched.
  * @return				Entity Index of the given weapon on success, INVALID_ENT_REFERENCE on failure.
  */
-stock Client_GiveWeaponAndAmmo(client, const String:className[], bool:switchTo=true, primaryAmmo=-1, secondaryAmmo=-1, primaryClip=-1, secondaryClip=-1)
+stock int Client_GiveWeaponAndAmmo(int client, const char[] className, bool switchTo=true, int primaryAmmo=-1, int secondaryAmmo=-1, int primaryClip=-1, int secondaryClip=-1)
 {
-	new weapon = Client_GiveWeapon(client, className, switchTo);
+	int weapon = Client_GiveWeapon(client, className, switchTo);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return INVALID_ENT_REFERENCE;
@@ -1264,14 +1261,14 @@ stock Client_GiveWeaponAndAmmo(client, const String:className[], bool:switchTo=t
  * @param clearAmmo		If true, the ammo the client carries for that weapon will be set to 0 (primary and secondary).
  * @return				True on success, false otherwise.
  */
-stock bool:Client_RemoveWeapon(client, const String:className[], bool:firstOnly=true, bool:clearAmmo=false)
+stock bool Client_RemoveWeapon(int client, const char[] className, bool firstOnly=true, bool clearAmmo=false)
 {
-	new offset = Client_GetWeaponsOffset(client) - 4;
+	int offset = Client_GetWeaponsOffset(client) - 4;
 
-	for (new i=0; i < MAX_WEAPONS; i++) {
+	for (int i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
-		new weapon = GetEntDataEnt2(client, offset);
+		int weapon = GetEntDataEnt2(client, offset);
 
 		if (!Weapon_IsValid(weapon)) {
 			continue;
@@ -1311,15 +1308,15 @@ stock bool:Client_RemoveWeapon(client, const String:className[], bool:firstOnly=
  * @param clearAmmo		If true, the ammo the player carries for all removed weapons are set to 0 (primary and secondary).
  * @return				Number of removed weapons.
  */
-stock Client_RemoveAllWeapons(client, const String:exclude[]="", bool:clearAmmo=false)
+stock int Client_RemoveAllWeapons(int client, const char exclude[]="", bool clearAmmo=false)
 {
-	new offset = Client_GetWeaponsOffset(client) - 4;
+	int offset = Client_GetWeaponsOffset(client) - 4;
 
-	new numWeaponsRemoved = 0;
-	for (new i=0; i < MAX_WEAPONS; i++) {
+	int numWeaponsRemoved = 0;
+	for (int i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
-		new weapon = GetEntDataEnt2(client, offset);
+		int weapon = GetEntDataEnt2(client, offset);
 
 		if (!Weapon_IsValid(weapon)) {
 			continue;
@@ -1351,9 +1348,9 @@ stock Client_RemoveAllWeapons(client, const String:exclude[]="", bool:clearAmmo=
  * @param className		Weapon Classname.
  * @return				True if client has the weapon, otherwise false.
  */
-stock bool:Client_HasWeapon(client, const String:className[])
+stock bool Client_HasWeapon(int client, const char[] className)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	return (weapon != INVALID_ENT_REFERENCE);
 }
@@ -1365,14 +1362,14 @@ stock bool:Client_HasWeapon(client, const String:className[])
  * @param className		Classname of the weapon.
  * @return				Entity index on success or INVALID_ENT_REFERENCE.
  */
-stock Client_GetWeapon(client, const String:className[])
+stock int Client_GetWeapon(int client, const char[] className)
 {
-	new offset = Client_GetWeaponsOffset(client) - 4;
-	new weapon = INVALID_ENT_REFERENCE;
-	for (new i=0; i < MAX_WEAPONS; i++) {
+	int offset = Client_GetWeaponsOffset(client) - 4;
+	int weapon = INVALID_ENT_REFERENCE;
+	for (int i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
-		weapon = GetEntDataEnt2(client, offset);
+		int weapon = GetEntDataEnt2(client, offset);
 
 		if (!Weapon_IsValid(weapon)) {
 			continue;
@@ -1395,7 +1392,7 @@ stock Client_GetWeapon(client, const String:className[])
  * @param slot			Slot Index.
  * @return				Entity index on success or INVALID_ENT_REFERENCE.
  */
-stock Client_GetWeaponBySlot(client, slot)
+stock int Client_GetWeaponBySlot(int client, int slot)
 {
 	return GetPlayerWeaponSlot(client, slot);
 }
@@ -1406,9 +1403,9 @@ stock Client_GetWeaponBySlot(client, slot)
  * @param client 		Client Index.
  * @return				Entity Index on success, INVALID_ENT_REFERENCE on failure.
  */
-stock Client_GetDefaultWeapon(client)
+stock int Client_GetDefaultWeapon(int client)
 {
-	decl String:weaponName[MAX_WEAPON_STRING];
+	char weaponName[MAX_WEAPON_STRING];
 	if (Client_GetDefaultWeaponName(client, weaponName, sizeof(weaponName))) {
 		return INVALID_ENT_REFERENCE;
 	}
@@ -1423,10 +1420,10 @@ stock Client_GetDefaultWeapon(client)
  *
  * @param client 		Client Index.
  * @param buffer		Buffer to store the default weapon's classname.
- * @param size			Max size of string: buffer.
+ * @param size			Max size of char buffer.
  * @return				True on success, false otherwise.
  */
-stock bool:Client_GetDefaultWeaponName(client, String:buffer[], size)
+stock bool Client_GetDefaultWeaponName(int client, char[] buffer, int size)
 {
 	if (!GetClientInfo(client, "cl_defaultweapon", buffer, size)) {
 		buffer[0] = '\0';
@@ -1443,14 +1440,14 @@ stock bool:Client_GetDefaultWeaponName(client, String:buffer[], size)
  * @param client 		Client Index.
  * @return				Entity Index of the weapon or INVALID_ENT_REFERENCE.
  */
-stock Client_GetFirstWeapon(client)
+stock int Client_GetFirstWeapon(int client)
 {
-	new offset = Client_GetWeaponsOffset(client) - 4;
+	int offset = Client_GetWeaponsOffset(client) - 4;
 
-	for (new i=0; i < MAX_WEAPONS; i++) {
+	for (int i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
-		new weapon = GetEntDataEnt2(client, offset);
+		int weapon = GetEntDataEnt2(client, offset);
 
 		if (!Weapon_IsValid(weapon)) {
 			continue;
@@ -1468,16 +1465,16 @@ stock Client_GetFirstWeapon(client)
  * @param client 		Client Index.
  * @return				Number of weapons.
  */
-stock Client_GetWeaponCount(client)
+stock int Client_GetWeaponCount(int client)
 {
-	new numWeapons = 0;
+	int numWeapons = 0;
 
-	new offset = Client_GetWeaponsOffset(client) - 4;
+	int offset = Client_GetWeaponsOffset(client) - 4;
 
 	for (new i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
-		new weapon = GetEntDataEnt2(client, offset);
+		int weapon = GetEntDataEnt2(client, offset);
 
 		if (!Weapon_IsValid(weapon)) {
 			continue;
@@ -1495,9 +1492,9 @@ stock Client_GetWeaponCount(client)
  * @param client 		Client Index.
  * @return				True if client is reloading, false otherwise.
  */
-stock bool:Client_IsReloading(client)
+stock bool Client_IsReloading(int client)
 {
-	new weapon = Client_GetActiveWeapon(client);
+	int weapon = Client_GetActiveWeapon(client);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return false;
@@ -1515,9 +1512,9 @@ stock bool:Client_IsReloading(client)
  * @param secondaryClip	Secondary ammo value in the weapon clip, if -1 the value is untouched.
  * @return				True on success, false on failure.
  */
-stock bool:Client_SetWeaponClipAmmo(client, const String:className[], primaryClip=-1, secondoaryClip=-1)
+stock bool Client_SetWeaponClipAmmo(int client, const char[] className, int primaryClip=-1, int secondaryClip=-1)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return false;
@@ -1527,7 +1524,7 @@ stock bool:Client_SetWeaponClipAmmo(client, const String:className[], primaryCli
 		Weapon_SetPrimaryClip(weapon, primaryClip);
 	}
 
-	if (secondoaryClip != -1) {
+	if (secondaryClip != -1) {
 		Weapon_SetSecondaryClip(weapon, primaryClip);
 	}
 
@@ -1543,23 +1540,23 @@ stock bool:Client_SetWeaponClipAmmo(client, const String:className[], primaryCli
  * @param secondaryAmmo	Secondary ammo stock from the client, if -1 the value is untouched.
  * @return				True on success, false on failure.
  */
-stock bool:Client_GetWeaponPlayerAmmo(client, const String:className[], &primaryAmmo=-1, &secondaryAmmo=-1)
+stock bool Client_GetWeaponPlayerAmmo(int client, const char[] className, int &primaryAmmo=-1, int &secondaryAmmo=-1)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return false;
 	}
 
-	new offset_ammo = FindDataMapInfo(client, "m_iAmmo");
+	int offset_ammo = FindDataMapInfo(client, "m_iAmmo");
 
 	if (primaryAmmo != -1) {
-		new offset = offset_ammo + (Weapon_GetPrimaryAmmoType(weapon) * 4);
+		int offset = offset_ammo + (Weapon_GetPrimaryAmmoType(weapon) * 4);
 		primaryAmmo = GetEntData(client, offset);
 	}
 
 	if (secondaryAmmo != -1) {
-		new offset = offset_ammo + (Weapon_GetSecondaryAmmoType(weapon) * 4);
+		int offset = offset_ammo + (Weapon_GetSecondaryAmmoType(weapon) * 4);
 		secondaryAmmo = GetEntData(client, offset);
 	}
 
@@ -1575,17 +1572,17 @@ stock bool:Client_GetWeaponPlayerAmmo(client, const String:className[], &primary
  * @param secondaryAmmo	Secondary ammo stock value from the client, if -1 the value is untouched.
  * @noreturn
  */
-stock Client_GetWeaponPlayerAmmoEx(client, weapon, &primaryAmmo=-1, &secondaryAmmo=-1)
+stock void Client_GetWeaponPlayerAmmoEx(int client, int weapon, int &primaryAmmo=-1, int &secondaryAmmo=-1)
 {
-	new offset_ammo = FindDataMapInfo(client, "m_iAmmo");
+	int offset_ammo = FindDataMapInfo(client, "m_iAmmo");
 
 	if (primaryAmmo != -1) {
-		new offset = offset_ammo + (Weapon_GetPrimaryAmmoType(weapon) * 4);
+		int offset = offset_ammo + (Weapon_GetPrimaryAmmoType(weapon) * 4);
 		primaryAmmo = GetEntData(client, offset);
 	}
 
 	if (secondaryAmmo != -1) {
-		new offset = offset_ammo + (Weapon_GetSecondaryAmmoType(weapon) * 4);
+		int offset = offset_ammo + (Weapon_GetSecondaryAmmoType(weapon) * 4);
 		secondaryAmmo = GetEntData(client, offset);
 	}
 }
@@ -1599,9 +1596,9 @@ stock Client_GetWeaponPlayerAmmoEx(client, weapon, &primaryAmmo=-1, &secondaryAm
  * @param secondaryAmmo	Secondary ammo stock from the client, if -1 the value is untouched.
  * @return				True on success, false on failure.
  */
-stock bool:Client_SetWeaponPlayerAmmo(client, const String:className[], primaryAmmo=-1, secondaryAmmo=-1)
+stock bool Client_SetWeaponPlayerAmmo(int client, const char[] className, int primaryAmmo=-1, int secondaryAmmo=-1)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return false;
@@ -1621,17 +1618,17 @@ stock bool:Client_SetWeaponPlayerAmmo(client, const String:className[], primaryA
  * @param secondaryAmmo	Secondary ammo stock value from the client, if -1 the value is untouched.
  * @noreturn
  */
-stock Client_SetWeaponPlayerAmmoEx(client, weapon, primaryAmmo=-1, secondaryAmmo=-1)
+stock void Client_SetWeaponPlayerAmmoEx(int client, int weapon, int primaryAmmo=-1, int secondaryAmmo=-1)
 {
-	new offset_ammo = FindDataMapInfo(client, "m_iAmmo");
+	int offset_ammo = FindDataMapInfo(client, "m_iAmmo");
 
 	if (primaryAmmo != -1) {
-		new offset = offset_ammo + (Weapon_GetPrimaryAmmoType(weapon) * 4);
+		int offset = offset_ammo + (Weapon_GetPrimaryAmmoType(weapon) * 4);
 		SetEntData(client, offset, primaryAmmo, 4, true);
 	}
 
 	if (secondaryAmmo != -1) {
-		new offset = offset_ammo + (Weapon_GetSecondaryAmmoType(weapon) * 4);
+		int offset = offset_ammo + (Weapon_GetSecondaryAmmoType(weapon) * 4);
 		SetEntData(client, offset, secondaryAmmo, 4, true);
 	}
 }
@@ -1645,11 +1642,11 @@ stock Client_SetWeaponPlayerAmmoEx(client, weapon, primaryAmmo=-1, secondaryAmmo
  * @param secondaryAmmo	Secondary ammo stock value from the client, if -1 the value is untouched.
  * @param primaryClip	Primary ammo value in the weapon clip, if -1 the value is untouched.
  * @param secondaryClip	Secondary ammo value in the weapon clip, if -1 the value is untouched.
- * @return				Entity Index of the given weapon on success, INVALID_ENT_REFERENCE on failure.
+ * @return				True on success, false on invalid weapon.
  */
-stock Client_SetWeaponAmmo(client, const String:className[], primaryAmmo=-1, secondaryAmmo=-1, primaryClip=-1, secondaryClip=-1)
+stock bool Client_SetWeaponAmmo(int client, const char[] className, int primaryAmmo=-1, int secondaryAmmo=-1, int primaryClip=-1, int secondaryClip=-1)
 {
-	new weapon = Client_GetWeapon(client, className);
+	int weapon = Client_GetWeapon(client, className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return false;
@@ -1673,11 +1670,11 @@ stock Client_SetWeaponAmmo(client, const String:className[], primaryAmmo=-1, sec
  * @param index			Reference to an index variable, will contain the index of the next weapon to check.
  * @return				Weapon Index or -1 if no more weapons are found.
  */
-stock Client_GetNextWeapon(client, &index = 0)
+stock int Client_GetNextWeapon(int client, int &index = 0)
 {
-	new offset = Client_GetWeaponsOffset(client) + (index * 4);
+	int offset = Client_GetWeaponsOffset(client) + (index * 4);
 
-	new weapon;
+	int weapon;
 	while (index < MAX_WEAPONS) {
 		index++;
 
@@ -1703,19 +1700,18 @@ stock Client_GetNextWeapon(client, &index = 0)
  * @param ...			Variable number of format parameters.
  * @return				True on success, false if this usermessage doesn't exist.
  */
-stock bool:Client_PrintHintText(client, const String:format[], any:...)
+stock bool Client_PrintHintText(int client, const char[] format, any ...)
 {
-	new Handle:userMessage = StartMessageOne("HintText", client);
+	Handle userMessage = StartMessageOne("HintText", client);
 
-	if (userMessage == INVALID_HANDLE) {
+	if (userMessage == null) {
 		return false;
 	}
 
-	decl String:buffer[254];
+	char buffer[254];
 
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 3);
-
 
 	if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available
 		&& GetUserMessageType() == UM_Protobuf) {
@@ -1741,11 +1737,11 @@ stock bool:Client_PrintHintText(client, const String:format[], any:...)
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintHintTextToAll(const String:format[], any:...)
+stock void Client_PrintHintTextToAll(const char[] format, any ...)
 {
-	decl String:buffer[254];
+	char buffer[254];
 
-	for (new client=1; client <= MaxClients; client++) {
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!IsClientInGame(client)) {
 			continue;
@@ -1767,15 +1763,15 @@ stock Client_PrintHintTextToAll(const String:format[], any:...)
  * @param ...			Variable number of format parameters.
  * @return				True on success, false if this usermessage doesn't exist.
  */
-stock bool:Client_PrintKeyHintText(client, const String:format[], any:...)
+stock bool Client_PrintKeyHintText(int client, const char[] format, any ...)
 {
-	new Handle:userMessage = StartMessageOne("KeyHintText", client);
+	Handle userMessage = StartMessageOne("KeyHintText", client);
 
-	if (userMessage == INVALID_HANDLE) {
+	if (userMessage == null) {
 		return false;
 	}
 
-	decl String:buffer[254];
+	char buffer[254];
 
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 3);
@@ -1804,11 +1800,11 @@ stock bool:Client_PrintKeyHintText(client, const String:format[], any:...)
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintKeyHintTextToAll(const String:format[], any:...)
+stock void Client_PrintKeyHintTextToAll(const char[] format, any ...)
 {
-	decl String:buffer[254];
+	char buffer[254];
 
-	for (new client=1; client <= MaxClients; client++) {
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!IsClientInGame(client)) {
 			continue;
@@ -1830,17 +1826,17 @@ stock Client_PrintKeyHintTextToAll(const String:format[], any:...)
  * @param isChat		Tells the game to handle the chat as normal (false) or chat message (true, plays a sound), only works if SayText2 is supported.
  * @noreturn
  */
-stock Client_PrintToChatRaw(client, const String:message[], subject=0, bool:isChat=false)
+stock void Client_PrintToChatRaw(int client, const char[] message, int subject=0, bool isChat=false)
 {
 	if (client == 0) {
-		decl String:buffer[253];
+		char buffer[253];
 		Color_StripFromChatText(message, buffer, sizeof(buffer));
 		PrintToServer(buffer);
 		return;
 	}
 
-	static sayText2_supported	= true;
-	static sayText2_checked		= false;
+	static bool sayText2_supported	= true;
+	static bool sayText2_checked		= false;
 
 	if (!sayText2_checked) {
 
@@ -1851,7 +1847,7 @@ stock Client_PrintToChatRaw(client, const String:message[], subject=0, bool:isCh
 		sayText2_checked = true;
 	}
 
-	new Handle:userMessage = INVALID_HANDLE;
+	Handle userMessage = null;
 
 	if (sayText2_supported) {
 		userMessage = StartMessageOne("SayText2", client, USERMSG_RELIABLE);
@@ -1909,22 +1905,20 @@ stock Client_PrintToChatRaw(client, const String:message[], subject=0, bool:isCh
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintToChat(client, bool:isChat, const String:format[], any:...)
+stock void Client_PrintToChat(int client, bool isChat, const char[] format, any ...)
 {
-	decl
-		String:buffer[512],
-		String:buffer2[253];
+	char buffer[512], buffer2[253];
 
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 4);
-	new subject = Color_ParseChatText(buffer, buffer2, sizeof(buffer2));
+	int subject = Color_ParseChatText(buffer, buffer2, sizeof(buffer2));
 
 	Client_PrintToChatRaw(client, buffer2, subject, isChat);
 
 	Color_ChatClearSubject();
 }
 
-static printToChat_excludeclient = -1;
+static int printToChat_excludeclient = -1;
 
 /**
  * Exclude a client from the next call to a Client_PrintToChat function.
@@ -1932,7 +1926,7 @@ static printToChat_excludeclient = -1;
  * @param client		Client Index.
  * @noreturn
  */
-stock Client_PrintToChatExclude(client)
+stock void Client_PrintToChatExclude(int client)
 {
 	printToChat_excludeclient = client;
 }
@@ -1947,17 +1941,12 @@ stock Client_PrintToChatExclude(client)
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintToChatAll(bool:isChat, const String:format[], any:...)
+stock void Client_PrintToChatAll(bool isChat, const char[] format, any ...)
 {
-	decl
-		String:buffer[512],
-		String:buffer2[253];
-	new
-		subject,
-		language,
-		lastLanguage = -1;
+	char buffer[512], buffer2[253];
+	int subject, language, lastLanguage = -1;
 
-	for (new client=1; client <= MaxClients; client++) {
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!IsClientInGame(client)) {
 			continue;
@@ -1996,18 +1985,12 @@ stock Client_PrintToChatAll(bool:isChat, const String:format[], any:...)
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintToChatEx(clients[], numClients, bool:isChat, const String:format[], any:...)
+stock void Client_PrintToChatEx(int[] clients, int numClients, bool isChat, const char[] format, any ...)
 {
-	decl
-		String:buffer[512],
-		String:buffer2[253];
-	new
-		client,
-		subject,
-		language,
-		lastLanguage = -1;
+	char buffer[512], buffer2[253];
+	int client, subject, language, lastLanguage = -1;
 
-	for (new i=0; i < numClients; i++) {
+	for (int i=0; i < numClients; i++) {
 
 		client = clients[i];
 
@@ -2054,9 +2037,9 @@ enum ClientHudPrint {
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintToConsole(client, const String:format[], any:...)
+stock void Client_PrintToConsole(int client, const char[] format, any ...)
 {
-	decl String:buffer[512];
+	char buffer[512];
 
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 3);
@@ -2076,21 +2059,21 @@ stock Client_PrintToConsole(client, const String:format[], any:...)
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_Print(client, ClientHudPrint:destination, const String:format[], any:...)
+stock void Client_Print(int client, ClientHudPrint destination, const char[] format, any ...)
 {
-	decl String:buffer[512], String:buffer2[254];
+	char buffer[512], buffer2[254];
 
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 4);
 
-	new subject = Color_ParseChatText(buffer, buffer2, sizeof(buffer2));
+	int subject = Color_ParseChatText(buffer, buffer2, sizeof(buffer2));
 
 	if (destination == ClientHudPrint_Talk) {
 		Client_PrintToChatRaw(client, buffer2, subject, false);
 		return;
 	}
 
-	new EngineVersion:engineVersion = GetEngineVersion();
+	EngineVersion engineVersion = GetEngineVersion();
 	if (client == 0 ||
 		destination != ClientHudPrint_Console ||
 		(destination == ClientHudPrint_Console
@@ -2104,13 +2087,13 @@ stock Client_Print(client, ClientHudPrint:destination, const String:format[], an
 		}
 	}
 
-	new Handle:userMessage = INVALID_HANDLE;
+	Handle userMessage = null;
 	userMessage = StartMessageOne("TextMsg", client, USERMSG_RELIABLE);
 
 	if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available
 		&& GetUserMessageType() == UM_Protobuf) {
 
-		PbSetInt(userMessage,    "msg_dst", _:destination);
+		PbSetInt(userMessage,    "msg_dst", view_as<int>(destination));
 		PbAddString(userMessage, "params",  buffer2);
 		PbAddString(userMessage, "params",  "");
 		PbAddString(userMessage, "params",  "");
@@ -2118,7 +2101,7 @@ stock Client_Print(client, ClientHudPrint:destination, const String:format[], an
 		PbAddString(userMessage, "params",  "");
 	}
 	else {
-		BfWriteByte(userMessage		, _:destination);
+		BfWriteByte(userMessage		, view_as<int>(destination));
 		BfWriteString(userMessage	, buffer2);
 	}
 
@@ -2136,9 +2119,9 @@ stock Client_Print(client, ClientHudPrint:destination, const String:format[], an
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_Reply(client, const String:format[], any:...)
+stock void Client_Reply(int client, const char[] format, any ...)
 {
-	decl String:buffer[255];
+	char buffer[255];
 
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 3);
@@ -2169,7 +2152,7 @@ stock Client_Reply(client, const String:format[], any:...)
  * @param duration		Shake lasts this long.
  * @return				True on success, false otherwise.
  */
-stock bool:Client_Shake(client, command=SHAKE_START, Float:amplitude=50.0, Float:frequency=150.0, Float:duration=3.0)
+stock bool Client_Shake(int client, int command=SHAKE_START, float amplitude=50.0, float frequency=150.0, float duration=3.0)
 {
 	if (command == SHAKE_STOP) {
 		amplitude = 0.0;
@@ -2178,9 +2161,9 @@ stock bool:Client_Shake(client, command=SHAKE_START, Float:amplitude=50.0, Float
 		return false;
 	}
 
-	new Handle:userMessage = StartMessageOne("Shake", client);
+	Handle userMessage = StartMessageOne("Shake", client);
 
-	if (userMessage == INVALID_HANDLE) {
+	if (userMessage == null) {
 		return false;
 	}
 
@@ -2210,9 +2193,9 @@ stock bool:Client_Shake(client, command=SHAKE_START, Float:amplitude=50.0, Float
  * @param				Client Index.
  * @return				True if the client is a generic admin, false otheriwse.
  */
-stock bool:Client_IsAdmin(client)
+stock bool Client_IsAdmin(int client)
 {
-	new AdminId:adminId = GetUserAdmin(client);
+	AdminId adminId = GetUserAdmin(client);
 
 	if (adminId == INVALID_ADMIN_ID) {
 		return false;
@@ -2227,15 +2210,15 @@ stock bool:Client_IsAdmin(client)
  * @param				Client Index.
  * @return				True if the client has the admin flags, false otherwise.
  */
-stock bool:Client_HasAdminFlags(client, flags=ADMFLAG_GENERIC)
+stock bool Client_HasAdminFlags(int client, int flags=ADMFLAG_GENERIC)
 {
-	new AdminId:adminId = GetUserAdmin(client);
+	AdminId adminId = GetUserAdmin(client);
 
 	if (adminId == INVALID_ADMIN_ID) {
 		return false;
 	}
 
-	return bool:(GetAdminFlags(adminId, Access_Effective) & flags);
+	return view_as<bool>(GetAdminFlags(adminId, Access_Effective) & flags);
 }
 
 /**
@@ -2246,9 +2229,9 @@ stock bool:Client_HasAdminFlags(client, flags=ADMFLAG_GENERIC)
  * @param caseSensitive	True if the group check has to be case sensitive, false otherwise.
  * @return              True if the client is in the admin group, false otherwise.
  */
-stock bool:Client_IsInAdminGroup(client, const String:groupName[], bool:caseSensitive=true)
+stock bool Client_IsInAdminGroup(int client, const char[] groupName, bool caseSensitive=true)
 {
-	new AdminId:adminId = GetUserAdmin(client);
+	AdminId adminId = GetUserAdmin(client);
 
 	// Validate id.
 	if (adminId == INVALID_ADMIN_ID) {
@@ -2256,17 +2239,17 @@ stock bool:Client_IsInAdminGroup(client, const String:groupName[], bool:caseSens
 	}
 
 	// Get number of groups.
-	new count = GetAdminGroupCount(adminId);
+	int count = GetAdminGroupCount(adminId);
 
 	// Validate number of groups.
 	if (count == 0) {
 		return false;
 	}
 
-	decl String:groupname[64];
+	char groupname[64];
 
 	// Loop through each group.
-	for (new i = 0; i < count; i++) {
+	for (int i = 0; i < count; i++) {
 		// Get group name.
 		GetAdminGroup(adminId, i, groupname, sizeof(groupname));
 
@@ -2288,26 +2271,26 @@ stock bool:Client_IsInAdminGroup(client, const String:groupName[], bool:caseSens
  * @param distance		Max Distance as Float value.
  * @return				True if he is looking at a wall, false otherwise.
  */
-stock bool:Client_IsLookingAtWall(client, Float:distance=40.0) {
+stock bool Client_IsLookingAtWall(int client, float distance=40.0) {
 
-	decl Float:posEye[3], Float:posEyeAngles[3];
-	new bool:isClientLookingAtWall = false;
+	float posEye[3], posEyeAngles[3];
+	bool isClientLookingAtWall = false;
 
 	GetClientEyePosition(client,	posEye);
 	GetClientEyeAngles(client,		posEyeAngles);
 
 	posEyeAngles[0] = 0.0;
 
-	new Handle:trace = TR_TraceRayFilterEx(posEye, posEyeAngles, CONTENTS_SOLID, RayType_Infinite, _smlib_TraceEntityFilter);
+	Handle trace = TR_TraceRayFilterEx(posEye, posEyeAngles, CONTENTS_SOLID, RayType_Infinite, _smlib_TraceEntityFilter);
 
 	if (TR_DidHit(trace)) {
 
 		if (TR_GetEntityIndex(trace) > 0) {
-			CloseHandle(trace);
+			delete trace;
 			return false;
 		}
 
-		decl Float:posEnd[3];
+		float posEnd[3];
 
 		TR_GetEndPosition(posEnd, trace);
 
@@ -2316,12 +2299,12 @@ stock bool:Client_IsLookingAtWall(client, Float:distance=40.0) {
 		}
 	}
 
-	CloseHandle(trace);
+	delete trace;
 
 	return isClientLookingAtWall;
 }
 
-public bool:_smlib_TraceEntityFilter(entity, contentsMask)
+public bool _smlib_TraceEntityFilter(int entity, int contentsMask)
 {
 	return entity == 0;
 }
@@ -2334,7 +2317,7 @@ public bool:_smlib_TraceEntityFilter(entity, contentsMask)
  * @param client		Client Index.
  * @return				Class Index.
  */
-stock Client_GetClass(client)
+stock int Client_GetClass(int client)
 {
 	if (GetEngineVersion() == Engine_DarkMessiah) {
 		return GetEntProp(client, Prop_Send, "m_iPlayerClass");
@@ -2353,7 +2336,7 @@ stock Client_GetClass(client)
  * @param persistant	If true changes the players desired class so the change stays after death (probably TF2 only).
  * @return				Class Index.
  */
-stock Client_SetClass(client, playerClass, bool:persistant=false)
+stock int Client_SetClass(int client, int playerClass, bool persistant=false)
 {
 	if (GetEngineVersion() == Engine_DarkMessiah) {
 		SetEntProp(client, Prop_Send, "m_iPlayerClass", playerClass);
@@ -2372,7 +2355,7 @@ stock Client_SetClass(client, playerClass, bool:persistant=false)
  * @param client		Client Index.
  * @return				Buttons as bitflag.
  */
-stock Client_GetButtons(client)
+stock int Client_GetButtons(int client)
 {
 	return GetClientButtons(client);
 }
@@ -2385,7 +2368,7 @@ stock Client_GetButtons(client)
  * @param buttons		Buttons as bitflag.
  * @noreturn
  */
-stock Client_SetButtons(client, buttons)
+stock void Client_SetButtons(int client, int buttons)
 {
 	SetEntProp(client, Prop_Data, "m_nButtons", buttons);
 }
@@ -2398,9 +2381,9 @@ stock Client_SetButtons(client, buttons)
  * @param buttons		Buttons as bitflag.
  * @noreturn
  */
-stock Client_AddButtons(client, buttons)
+stock void Client_AddButtons(int client, int buttons)
 {
-	new newButtons = Client_GetButtons(client);
+	int newButtons = Client_GetButtons(client);
 	newButtons |= buttons;
 	Client_SetButtons(client, newButtons);
 }
@@ -2413,9 +2396,9 @@ stock Client_AddButtons(client, buttons)
  * @param buttons		Buttons as bitflag.
  * @noreturn
  */
-stock Client_RemoveButtons(client, buttons)
+stock void Client_RemoveButtons(int client, int buttons)
 {
-	new newButtons = Client_GetButtons(client);
+	int newButtons = Client_GetButtons(client);
 	newButtons &= ~buttons;
 	Client_SetButtons(client, newButtons);
 }
@@ -2427,7 +2410,7 @@ stock Client_RemoveButtons(client, buttons)
  * @param client		Client Index.
  * @noreturn
  */
-stock Client_ClearButtons(client)
+stock void Client_ClearButtons(int client)
 {
 	Client_SetButtons(client,0);
 }
@@ -2439,9 +2422,9 @@ stock Client_ClearButtons(client)
  * @param buttons		Buttons as bitflag.
  * @return				True if the buttons are pressed otherwise false.
  */
-stock bool:Client_HasButtons(client, buttons)
+stock bool Client_HasButtons(int client, int buttons)
 {
-	return bool:(Client_GetButtons(client) & buttons);
+	return view_as<bool>(Client_GetButtons(client) & buttons);
 }
 
 /**
@@ -2450,14 +2433,14 @@ stock bool:Client_HasButtons(client, buttons)
  *
  * @param client		Client Index.
  * @param buttons		Buttons as bitflag.
- * @return
+ * @return				Return changed buttons
  */
-stock Client_GetChangedButtons(client)
+stock int Client_GetChangedButtons(int client)
 {
-	static oldButtons[MAXPLAYERS+1] = {0,...};
+	static int oldButtons[MAXPLAYERS+1] = {0,...};
 
-	new buttons = Client_GetButtons(client);
-	new changedButtons = buttons ^ oldButtons[client];
+	int buttons = Client_GetButtons(client);
+	int changedButtons = buttons ^ oldButtons[client];
 
 	oldButtons[client] = buttons;
 
@@ -2471,7 +2454,7 @@ stock Client_GetChangedButtons(client)
  * @param maxspeed	the maximum speed the client can move
  * @noreturn
  */
-stock Client_SetMaxSpeed(client, Float:value)
+stock void Client_SetMaxSpeed(int client, float value)
 {
 	Entity_SetMaxSpeed(client, value);
 }
@@ -2486,7 +2469,7 @@ stock Client_SetMaxSpeed(client, Float:value)
  * @param path			Overlay path (based on the game/materials/ folder) or empty String to not show any overlay.
  * @noreturn
  */
-stock Client_SetScreenOverlay(client, const String:path[])
+stock void Client_SetScreenOverlay(int client, const char[] path)
 {
 	ClientCommand(client, "r_screenoverlay \"%s\"", path);
 }
@@ -2501,7 +2484,7 @@ stock Client_SetScreenOverlay(client, const String:path[])
  * @param path			Overlay path (based on the game/materials/ folder) or empty String to not show any overlay.
  * @noreturn
  */
-stock Client_SetScreenOverlayForAll(const String:path[])
+stock void Client_SetScreenOverlayForAll(const char[] path)
 {
 	LOOP_CLIENTS(client, CLIENTFILTER_INGAME | CLIENTFILTER_NOBOTS) {
 		Client_SetScreenOverlay(client, path);
@@ -2514,7 +2497,7 @@ stock Client_SetScreenOverlayForAll(const String:path[])
  * @param Client		Client Index.
  * @noreturn
  */
-stock Client_Mute(client)
+stock void Client_Mute(int client)
 {
 	SetClientListeningFlags(client, VOICE_MUTED);
 }
@@ -2526,22 +2509,22 @@ stock Client_Mute(client)
  * @param Client		Client Index.
  * @noreturn
  */
-stock Client_UnMute(client)
+stock void Client_UnMute(int client)
 {
-	static Handle:cvDeadTalk = INVALID_HANDLE;
+	static ConVar cvDeadTalk;
 
-	if (cvDeadTalk == INVALID_HANDLE) {
+	if (cvDeadTalk == null) {
 		cvDeadTalk = FindConVar("sm_deadtalk");
 	}
 
-	if (cvDeadTalk == INVALID_HANDLE) {
+	if (cvDeadTalk == null) {
 		SetClientListeningFlags(client, VOICE_NORMAL);
 	}
 	else {
-		if (GetConVarInt(cvDeadTalk) == 1 && !IsPlayerAlive(client)) {
+		if (cvDeadTalk.IntValue == 1 && !IsPlayerAlive(client)) {
 			SetClientListeningFlags(client, VOICE_LISTENALL);
 		}
-		else if (GetConVarInt(cvDeadTalk) == 2 && !IsPlayerAlive(client)) {
+		else if (cvDeadTalk.IntValue == 2 && !IsPlayerAlive(client)) {
 			SetClientListeningFlags(client, VOICE_TEAM);
 		}
 		else {
@@ -2553,12 +2536,12 @@ stock Client_UnMute(client)
 /**
  * Checks if a client's voice is muted
  *
- * @param Client		Client Index.
+ * @param client		Client Index.
  * @return				True if the client is muted, false otherwise.
  */
-stock bool:Client_IsMuted(client)
+stock bool Client_IsMuted(int client)
 {
-	return bool:(GetClientListeningFlags(client) & VOICE_MUTED);
+	return view_as<bool>(GetClientListeningFlags(client) & VOICE_MUTED);
 }
 
 /**
@@ -2568,13 +2551,13 @@ stock bool:Client_IsMuted(client)
  * so you don't have to do that yourself.
  * This function is optimized to make as less native calls as possible :)
  *
- * @param Client		Client Index.
+ * @param client		Client Index.
  * @param flags			Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @return				True if the client if the client matches, false otherwise.
  */
-stock bool:Client_MatchesFilter(client, flags)
+stock bool Client_MatchesFilter(int client, int flags)
 {
-	new bool:isIngame = false;
+	bool isIngame = false;
 
 	if (flags >= CLIENTFILTER_INGAME) {
 		isIngame = IsClientInGame(client);
@@ -2669,10 +2652,10 @@ stock bool:Client_MatchesFilter(client, flags)
  * @param flags			Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @return				The number of clients stored in the array
  */
-stock Client_Get(clients[], flags=CLIENTFILTER_ALL)
+stock int Client_Get(int[] clients, int flags=CLIENTFILTER_ALL)
 {
-	new x=0;
-	for (new client = 1; client <= MaxClients; client++) {
+	int x=0;
+	for (int client = 1; client <= MaxClients; client++) {
 
 		if (!Client_MatchesFilter(client, flags)) {
 			continue;
@@ -2690,10 +2673,10 @@ stock Client_Get(clients[], flags=CLIENTFILTER_ALL)
  * @param flags			Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @return				Client Index or -1 if no client was found
  */
-stock Client_GetRandom(flags=CLIENTFILTER_ALL)
+stock int Client_GetRandom(int flags=CLIENTFILTER_ALL)
 {
-	decl clients[MaxClients];
-	new num = Client_Get(clients, flags);
+	int[] clients = new int[MaxClients];
+	int num = Client_Get(clients, flags);
 
 	if (num == 0) {
 		return -1;
@@ -2702,7 +2685,7 @@ stock Client_GetRandom(flags=CLIENTFILTER_ALL)
 		return clients[0];
 	}
 
-	new random = Math_GetRandomInt(0, num-1);
+	int random = Math_GetRandomInt(0, num-1);
 
 	return clients[random];
 }
@@ -2714,9 +2697,9 @@ stock Client_GetRandom(flags=CLIENTFILTER_ALL)
  * @param start			Start Index.
  * @return				Client Index or -1 if no client was found
  */
-stock Client_GetNext(flags, start=1)
+stock int Client_GetNext(int flags, int start=1)
 {
-	for (new client=start; client <= MaxClients; client++) {
+	for (int client=start; client <= MaxClients; client++) {
 
 		if (Client_MatchesFilter(client, flags)) {
 			return client;
@@ -2732,10 +2715,10 @@ stock Client_GetNext(flags, start=1)
  * @param client		Client Index.
  * @return				Time in seconds as Float
  */
-stock Float:Client_GetMapTime(client)
+stock float Client_GetMapTime(int client)
 {
-	new Float:fClientTime = GetClientTime(client);
-	new Float:fGameTime = GetGameTime();
+	float fClientTime = GetClientTime(client);
+	float fGameTime = GetGameTime();
 
 	return (fClientTime < fGameTime) ? fClientTime : fGameTime;
 }
@@ -2746,7 +2729,7 @@ stock Float:Client_GetMapTime(client)
  * @param client		Client Index.
  * @return				Money value from the client.
  */
-stock Client_GetMoney(client)
+stock int Client_GetMoney(int client)
 {
 	return GetEntProp(client, Prop_Send, "m_iAccount");
 }
@@ -2758,7 +2741,7 @@ stock Client_GetMoney(client)
  * @param value			Money value to set.
  * @noreturn
  */
-stock Client_SetMoney(client, value)
+stock void Client_SetMoney(int client, any value)
 {
 	SetEntProp(client, Prop_Send, "m_iAccount", value);
 }
@@ -2771,9 +2754,9 @@ stock Client_SetMoney(client, value)
  * @param flags			Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @return				Number of observers found.
  */
-stock Client_GetObservers(client, observers[], flags=CLIENTFILTER_ALL)
+stock int Client_GetObservers(int client, int[] observers, int flags=CLIENTFILTER_ALL)
 {
-	new count = 0;
+	int count = 0;
 
 	LOOP_CLIENTS(player, CLIENTFILTER_OBSERVERS | flags) {
 
@@ -2785,7 +2768,7 @@ stock Client_GetObservers(client, observers[], flags=CLIENTFILTER_ALL)
 	return count;
 }
 
-static Float:getPlayersInRadius_distances[MAXPLAYERS+1];
+static float getPlayersInRadius_distances[MAXPLAYERS+1];
 
 /**
  * Gets all players near a player in a certain radius and
@@ -2797,12 +2780,10 @@ static Float:getPlayersInRadius_distances[MAXPLAYERS+1];
  * @param orderByDistance	Set to true to order the clients by distance, false otherwise.
  * @return					Number of clients found.
  */
-stock Client_GetPlayersInRadius(client, clients[], Float:radius, bool:orderByDistance=true)
+stock int Client_GetPlayersInRadius(int client, int[] clients, float radius, bool orderByDistance=true)
 {
-	decl Float:origin_client[3];
-	new
-		Float:distance,
-		count=0;
+	float origin_client[3], distance;
+	int count=0;
 
 	Entity_GetAbsOrigin(client, origin_client);
 
@@ -2830,7 +2811,7 @@ stock Client_GetPlayersInRadius(client, clients[], Float:radius, bool:orderByDis
 	return count;
 }
 
-public __smlib_GetPlayersInRadius_Sort(player1, player2, const clients[], Handle:hndl)
+public int __smlib_GetPlayersInRadius_Sort(int player1, int player2, const int[] clients, Handle hndl)
 {
 	return FloatCompare(getPlayersInRadius_distances[player1], getPlayersInRadius_distances[player2]);
 }
@@ -2843,9 +2824,9 @@ public __smlib_GetPlayersInRadius_Sort(player1, player2, const clients[], Handle
  * @param flags			Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @return				Client Index or -1 if no client was found
  */
-stock Client_GetNextObserver(client, start=1, flags=CLIENTFILTER_ALL)
+stock int Client_GetNextObserver(int client, int start=1, int flags=CLIENTFILTER_ALL)
 {
-	for (new player=start; player <= MaxClients; player++) {
+	for (int player=start; player <= MaxClients; player++) {
 
 		if (Client_MatchesFilter(player, CLIENTFILTER_OBSERVERS | flags)) {
 
@@ -2864,9 +2845,9 @@ stock Client_GetNextObserver(client, start=1, flags=CLIENTFILTER_ALL)
  *
  * @return				player_manager entity or INVALID_ENT_REFERENCE if not found.
  */
-stock Client_GetPlayerManager()
+stock int Client_GetPlayerManager()
 {
-	static player_manager = INVALID_ENT_REFERENCE;
+	static int player_manager = INVALID_ENT_REFERENCE;
 
 	if (player_manager != INVALID_ENT_REFERENCE) {
 
@@ -2878,9 +2859,9 @@ stock Client_GetPlayerManager()
 		}
 	}
 
-	new maxEntities = GetMaxEntities();
+	int maxEntities = GetMaxEntities();
 
-	for (new entity=0; entity < maxEntities; entity++) {
+	for (int entity=0; entity < maxEntities; entity++) {
 
 		if (!Entity_IsValid(entity)) {
 			continue;
@@ -2904,11 +2885,11 @@ stock Client_GetPlayerManager()
  * @param start			New ping value.
  * @return				True on sucess, false otherwise.
  */
-stock Client_SetPing(client, value)
+stock bool Client_SetPing(client, value)
 {
-	new player_manager = Client_GetPlayerManager();
+	int player_manager = Client_GetPlayerManager();
 
-	static offset = -1;
+	static int offset = -1;
 
 	if (offset== -1) {
 		offset = GetEntSendPropOffs(player_manager, "m_iPing", true);
@@ -2923,7 +2904,7 @@ stock Client_SetPing(client, value)
 	return true;
 }
 
-static printToTop_excludeclient = -1;
+static int printToTop_excludeclient = -1;
 
 /**
  * Exclude a client from the next call to a Client_PrintToTop function.
@@ -2931,7 +2912,7 @@ static printToTop_excludeclient = -1;
  * @param client		Client Index.
  * @noreturn
  */
-stock Client_PrintToTopExclude(client)
+stock void Client_PrintToTopExclude(int client)
 {
 	printToTop_excludeclient = client;
 }
@@ -2950,24 +2931,25 @@ stock Client_PrintToTopExclude(client)
  * @param text			Text to print to.
  * @return				True on success, false if the key value for the dialog couldn't be created or closed.
  */
-stock bool:Client_PrintToTopRaw(client, r=255, g=255, b=255, a=255, Float:duration=10.0, const String:text[])
+stock bool Client_PrintToTopRaw(int client, int r=255, int g=255, int b=255, int a=255, float duration=10.0, const char[] text)
 {
 	//message line max 50
 	//overline: 	39*_
 	//underline: 	44*T
-	new Handle:keyValue = CreateKeyValues("Stuff", "title", text);
+	KeyValues keyValue = new KeyValues("Stuff", "title", text);
 
-	if (keyValue == INVALID_HANDLE) {
+	if (keyValue == null) {
 		return false;
 	}
 
-	KvSetColor(keyValue, "color", r, g, b, a);
-	KvSetNum(keyValue, "level", 1);
-	KvSetNum(keyValue, "time", RoundToFloor(duration));
+	keyValue.SetColor("color", r, g, b, a);
+	keyValue.SetNum("level", 1);
+	keyValue.SetNum("time", RoundToFloor(duration));
 
 	CreateDialog(client, keyValue, DialogType_Msg);
 
-	if (!CloseHandle(keyValue)) {
+	delete keyValue;
+	if (keyValue != null) {
 		return false;
 	}
 	return true;
@@ -2988,9 +2970,9 @@ stock bool:Client_PrintToTopRaw(client, r=255, g=255, b=255, a=255, Float:durati
  * @param ...			Variable number of format parameters.
  * @return				True on success, false if the key value for the dialog couldn't be created or closed.
  */
-stock bool:Client_PrintToTop(client, r=255, g=255, b=255, a=255, Float:duration=10.0, const String:format[], any:...)
+stock bool Client_PrintToTop(int client, int r=255, int g=255, int b=255, int a=255, float duration=10.0, const char[] format, any ...)
 {
-	new String:buffer[150];
+	char buffer[150];
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), format, 8);
 
@@ -3011,15 +2993,12 @@ stock bool:Client_PrintToTop(client, r=255, g=255, b=255, a=255, Float:duration=
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintToTopAll(r=255, g=255, b=255, a=255, Float:duration=10.0, const String:format[], any:...)
+stock void Client_PrintToTopAll(int r=255, int g=255, int b=255, int a=255, float duration=10.0, const char[] format, any ...)
 {
-	decl
-		String:buffer[150];
-	new
-		language,
-		lastLanguage = -1;
+	char buffer[150];
+	int language, lastLanguage = -1;
 
-	for (new client=1; client <= MaxClients; client++) {
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!IsClientInGame(client)) {
 			continue;
@@ -3059,16 +3038,12 @@ stock Client_PrintToTopAll(r=255, g=255, b=255, a=255, Float:duration=10.0, cons
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock Client_PrintToTopEx(clients[], numClients, r=255, g=255, b=255, a=255, Float:duration=10.0, const String:format[], any:...)
+stock void Client_PrintToTopEx(int[] clients, int numClients, int r=255, int g=255, int b=255, int a=255, float duration=10.0, const char[] format, any ...)
 {
-	decl
-		String:buffer[150];
-	new
-		client,
-		language,
-		lastLanguage = -1;
+	char buffer[150];
+	int client, language, lastLanguage = -1;
 
-	for (new i=0; i < numClients; i++) {
+	for (int i=0; i < numClients; i++) {
 
 		client = clients[i];
 
@@ -3101,9 +3076,9 @@ stock Client_PrintToTopEx(clients[], numClients, r=255, g=255, b=255, a=255, Flo
  * @param client	Client index
  * @noreturn
  */
-stock Client_ShowScoreboard(client, flags=USERMSG_RELIABLE | USERMSG_BLOCKHOOKS)
+stock void Client_ShowScoreboard(int client, int flags=USERMSG_RELIABLE | USERMSG_BLOCKHOOKS)
 {
-	new Handle:handle = StartMessageOne("VGUIMenu", client, flags);
+	Handle handle = StartMessageOne("VGUIMenu", client, flags);
 
 	if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available &&
 			GetUserMessageType() == UM_Protobuf) {

--- a/scripting/include/smlib/clients.inc
+++ b/scripting/include/smlib/clients.inc
@@ -619,7 +619,7 @@ stock void Client_SetSuitSprintPower(int client, float power)
  * @param countBots		If true bots will be counted too.
  * @return				Client count in the server.
  */
-stock void Client_GetCount(bool countInGameOnly=true, bool countFakeClients=true)
+stock int Client_GetCount(bool countInGameOnly=true, bool countFakeClients=true)
 {
 	int numClients = 0;
 
@@ -1369,7 +1369,7 @@ stock int Client_GetWeapon(int client, const char[] className)
 	for (int i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
-		int weapon = GetEntDataEnt2(client, offset);
+		weapon = GetEntDataEnt2(client, offset);
 
 		if (!Weapon_IsValid(weapon)) {
 			continue;
@@ -1471,7 +1471,7 @@ stock int Client_GetWeaponCount(int client)
 
 	int offset = Client_GetWeaponsOffset(client) - 4;
 
-	for (new i=0; i < MAX_WEAPONS; i++) {
+	for (int i=0; i < MAX_WEAPONS; i++) {
 		offset += 4;
 
 		int weapon = GetEntDataEnt2(client, offset);
@@ -2882,10 +2882,10 @@ stock int Client_GetPlayerManager()
  * Should be called OnGameFrame.
  *
  * @param client		Client Index
- * @param start			New ping value.
+ * @param value			New ping value.
  * @return				True on sucess, false otherwise.
  */
-stock bool Client_SetPing(client, value)
+stock bool Client_SetPing(int client, int value)
 {
 	int player_manager = Client_GetPlayerManager();
 

--- a/scripting/include/smlib/colors.inc
+++ b/scripting/include/smlib/colors.inc
@@ -45,7 +45,7 @@ enum ChatColor
 	ChatColor_Black
 }
 
-static String:chatColorTags[][] = {
+static char chatColorTags[][] = {
 	"N",	// Normal
 	"O",	// Orange
 	"R",	// Red
@@ -60,7 +60,7 @@ static String:chatColorTags[][] = {
 	"BLA"	// BLAck
 };
 
-static String:chatColorNames[][] = {
+static char chatColorNames[][] = {
 	"normal",		// Normal
 	"orange",		// Orange
 	"red",			// Red
@@ -75,15 +75,15 @@ static String:chatColorNames[][] = {
 	"black"			// BLAck
 };
 
-static chatColorInfo[][ChatColorInfo] =
+static int chatColorInfo[][ChatColorInfo] =
 {
 	// Code , alternative	, Is Supported?	Chat color subject type 		   Color name
 	{ '\x01', -1/* None	 */	, true,			ChatColorSubjectType_none,	},	// Normal
 	{ '\x01', 0	/* None	 */	, true,			ChatColorSubjectType_none,	},	// Orange
-	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType:2		},	// Red
-	{ '\x03', 4	/* Blue	 */	, true,			ChatColorSubjectType:2		},	// Red, Blue
-	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType:3		},	// Blue
-	{ '\x03', 2	/* Red	 */	, true,			ChatColorSubjectType:3		},	// Blue, Red
+	{ '\x03', 9	/* Green */	, true,			view_as<ChatColorSubjectType>(2)		},	// Red
+	{ '\x03', 4	/* Blue	 */	, true,			view_as<ChatColorSubjectType>(2)		},	// Red, Blue
+	{ '\x03', 9	/* Green */	, true,			view_as<ChatColorSubjectType>(3)		},	// Blue
+	{ '\x03', 2	/* Red	 */	, true,			view_as<ChatColorSubjectType>(3)		},	// Blue, Red
 	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType_player	},	// Team
 	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType_world	},	// Light green
 	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType_undefined},// GRAy
@@ -92,10 +92,10 @@ static chatColorInfo[][ChatColorInfo] =
 	{ '\x06', 9	/* Green */	, true,			ChatColorSubjectType_none	}	// BLAck
 };
 
-static bool:checkTeamPlay			= false;
-static Handle:mp_teamplay			= INVALID_HANDLE;
-static bool:isSayText2_supported	= true;
-static chatSubject					= CHATCOLOR_NOSUBJECT;
+static bool checkTeamPlay			= false;
+static ConVar mp_teamplay			= null;
+static bool isSayText2_supported	= true;
+static int chatSubject					= CHATCOLOR_NOSUBJECT;
 
 /**
  * Sets the subject (a client) for the chat color parser.
@@ -104,7 +104,7 @@ static chatSubject					= CHATCOLOR_NOSUBJECT;
  * @param client			Client Index/Subject
  * @noreturn
  */
-stock Color_ChatSetSubject(client)
+stock void Color_ChatSetSubject(int client)
 {
 	chatSubject = client;
 }
@@ -114,7 +114,7 @@ stock Color_ChatSetSubject(client)
  *
  * @return					Client Index/Subject, or CHATCOLOR_NOSUBJECT if none
  */
-stock Color_ChatGetSubject()
+stock int Color_ChatGetSubject()
 {
 	return chatSubject;
 }
@@ -125,7 +125,7 @@ stock Color_ChatGetSubject()
  *
  * @noreturn
  */
-stock Color_ChatClearSubject()
+stock void Color_ChatClearSubject()
 {
 	chatSubject = CHATCOLOR_NOSUBJECT;
 }
@@ -141,19 +141,15 @@ stock Color_ChatClearSubject()
  * @param size				Output Buffer size
  * @return					Returns a value for the subject
  */
-stock Color_ParseChatText(const String:str[], String:buffer[], size)
+stock int Color_ParseChatText(const char[] str, char[] buffer, int size)
 {
-	new
-		bool:inBracket = false,
-		x = 0, x_buf = 0, x_tag = 0,
-		subject = CHATCOLOR_NOSUBJECT;
-
-	decl
-		String:sTag[10]         = "",     // This should be able to hold "\x08RRGGBBAA"\0
-		String:colorCode[10]    = "",     // This should be able to hold "\x08RRGGBBAA"\0
-		String:currentColor[10] = "\x01"; // Initialize with normal color
+	bool inBracket = false;
+	int x = 0, x_buf = 0, x_tag = 0, subject = CHATCOLOR_NOSUBJECT;
 
 	size--;
+	char sTag[10]         = "",     // This should be able to hold "\x08RRGGBBAA"\0
+		colorCode[10]    = "",     // This should be able to hold "\x08RRGGBBAA"\0
+		currentColor[10] = "\x01"; // Initialize with normal color
 
 	// Every chat message has to start with a
 	// color code, otherwise it will ignore all colors.
@@ -165,14 +161,14 @@ stock Color_ParseChatText(const String:str[], String:buffer[], size)
 			break;
 		}
 
-		new character = str[x++];
+		char character = str[x++];
 
 		if (inBracket) {
 			// We allow up to 9 characters in the tag (#RRGGBBAA)
 			if (character == '}' || x_tag > 9) {
 				inBracket   = false;
 				sTag[x_tag] = '\0';
-				x_tag       = 0;
+				x_tag 		= 0;
 
 				if (character == '}') {
 					Color_TagToCode(sTag, subject, colorCode);
@@ -245,12 +241,12 @@ stock Color_ParseChatText(const String:str[], String:buffer[], size)
  * @param result            The result as character sequence (string). This will be \0 if the tag is unkown.
  * @noreturn
  */
-stock Color_TagToCode(const String:tag[], &subject=-1, String:result[10])
+stock void Color_TagToCode(const char[] tag, int &subject=-1, char result[10])
 {
 	// Check if the tag starts with a '#'.
 	// We will handle it has RGB(A)-color code then.
 	if (tag[0] == '#') {
-		new length_tag = strlen(tag);
+		int length_tag = strlen(tag);
 		switch (length_tag - 1) {
 			// #RGB      -> \07RRGGBB
 			case 3: {
@@ -279,11 +275,10 @@ stock Color_TagToCode(const String:tag[], &subject=-1, String:result[10])
 			}
 		}
 
-		return;
 	}
 	else {
 		// Try to handle this string as color name
-		new n = Array_FindString(chatColorTags, sizeof(chatColorTags), tag);
+		int n = Array_FindString(chatColorTags, sizeof(chatColorTags), tag);
 
 		// Check if this tag is invalid
 		if (n == -1) {
@@ -298,7 +293,6 @@ stock Color_TagToCode(const String:tag[], &subject=-1, String:result[10])
 		result[1] = '\0';
 	}
 
-	return;
 }
 
 /**
@@ -311,16 +305,16 @@ stock Color_TagToCode(const String:tag[], &subject=-1, String:result[10])
  * @param size				Max Size of the Output string
  * @noreturn
  */
-stock Color_StripFromChatText(const String:input[], String:output[], size)
+stock void Color_StripFromChatText(const char[] input, char[] output, int size)
 {
-	new x = 0;
-	for (new i=0; input[i] != '\0'; i++) {
+	int x = 0;
+	for (int i=0; input[i] != '\0'; i++) {
 
 		if (x+1 == size) {
 			break;
 		}
 
-		new character = input[i];
+		char character = input[i];
 
 		if (character > 0x08) {
 			output[x++] = character;
@@ -339,9 +333,9 @@ stock Color_StripFromChatText(const String:input[], String:output[], size)
  *
  * @noreturn
  */
-static stock Color_ChatInitialize()
+static stock void Color_ChatInitialize()
 {
-	static initialized = false;
+	static bool initialized = false;
 
 	if (initialized) {
 		return;
@@ -349,7 +343,7 @@ static stock Color_ChatInitialize()
 
 	initialized = true;
 
-	decl String:gameFolderName[32];
+	char gameFolderName[32];
 	GetGameFolderName(gameFolderName, sizeof(gameFolderName));
 
 	chatColorInfo[ChatColor_Black][ChatColorInfo_Supported]		    = false;
@@ -369,19 +363,19 @@ static stock Color_ChatInitialize()
 		chatColorInfo[ChatColor_Gray][ChatColorInfo_SubjectType]	= ChatColorSubjectType_none;
 	}
 	else if (strncmp(gameFolderName, "left4dead", 9, false) == 0) {
-		chatColorInfo[ChatColor_Red][ChatColorInfo_SubjectType]		= ChatColorSubjectType:3;
-		chatColorInfo[ChatColor_RedBlue][ChatColorInfo_SubjectType]	= ChatColorSubjectType:3;
-		chatColorInfo[ChatColor_Blue][ChatColorInfo_SubjectType]	= ChatColorSubjectType:2;
-		chatColorInfo[ChatColor_BlueRed][ChatColorInfo_SubjectType]	= ChatColorSubjectType:2;
+		chatColorInfo[ChatColor_Red][ChatColorInfo_SubjectType]		= view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_RedBlue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_Blue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
+		chatColorInfo[ChatColor_BlueRed][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
 
 		chatColorInfo[ChatColor_Orange][ChatColorInfo_Code]			= '\x04';
 		chatColorInfo[ChatColor_Green][ChatColorInfo_Code]			= '\x05';
 	}
 	else if (StrEqual(gameFolderName, "hl2mp", false)) {
-		chatColorInfo[ChatColor_Red][ChatColorInfo_SubjectType]		= ChatColorSubjectType:3;
-		chatColorInfo[ChatColor_RedBlue][ChatColorInfo_SubjectType]	= ChatColorSubjectType:3;
-		chatColorInfo[ChatColor_Blue][ChatColorInfo_SubjectType]	= ChatColorSubjectType:2;
-		chatColorInfo[ChatColor_BlueRed][ChatColorInfo_SubjectType]	= ChatColorSubjectType:2;
+		chatColorInfo[ChatColor_Red][ChatColorInfo_SubjectType]		= view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_RedBlue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_Blue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
+		chatColorInfo[ChatColor_BlueRed][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
 		chatColorInfo[ChatColor_Black][ChatColorInfo_Supported]		= true;
 
 		checkTeamPlay												= true;
@@ -398,17 +392,17 @@ static stock Color_ChatInitialize()
 		isSayText2_supported = false;
 	}
 
-	decl String:path_gamedata[PLATFORM_MAX_PATH];
+	char path_gamedata[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, path_gamedata, sizeof(path_gamedata), "gamedata/%s.txt", SMLIB_COLORS_GAMEDATAFILE);
 
 	if (FileExists(path_gamedata)) {
-		new Handle:gamedata = INVALID_HANDLE;
+		Handle gamedata = null;
 
-		if ((gamedata = LoadGameConfigFile(SMLIB_COLORS_GAMEDATAFILE)) != INVALID_HANDLE) {
+		if ((gamedata = LoadGameConfigFile(SMLIB_COLORS_GAMEDATAFILE)) != null) {
 
-			decl String:keyName[32], String:buffer[6];
+			char keyName[32], buffer[6];
 
-			for (new i=0; i < sizeof(chatColorNames); i++) {
+			for (int i=0; i < sizeof(chatColorNames); i++) {
 
 				Format(keyName, sizeof(keyName), "%s_code",			chatColorNames[i]);
 				if (GameConfGetKeyValue(gamedata, keyName, buffer, sizeof(buffer))) {
@@ -427,7 +421,7 @@ static stock Color_ChatInitialize()
 
 				Format(keyName, sizeof(keyName), "%s_subjecttype",	chatColorNames[i]);
 				if (GameConfGetKeyValue(gamedata, keyName, buffer, sizeof(buffer))) {
-					chatColorInfo[i][ChatColorInfo_SubjectType]		= ChatColorSubjectType:StringToInt(buffer);
+					chatColorInfo[i][ChatColorInfo_SubjectType]		= view_as<ChatColorSubjectType>(StringToInt(buffer));
 				}
 			}
 
@@ -435,7 +429,7 @@ static stock Color_ChatInitialize()
 				checkTeamPlay = StrEqual(buffer, "true");
 			}
 
-			CloseHandle(gamedata);
+			delete gamedata;
 		}
 	}
 
@@ -449,9 +443,9 @@ static stock Color_ChatInitialize()
  *
  * @param index
  * @param subject A client index or CHATCOLOR_NOSUBJECT
- * @noreturn
+ * @return new subject client index for team colors
  */
-static stock Color_GetChatColorInfo(&index, &subject=CHATCOLOR_NOSUBJECT)
+static stock int Color_GetChatColorInfo(int &index, int &subject=CHATCOLOR_NOSUBJECT)
 {
 	Color_ChatInitialize();
 
@@ -461,7 +455,7 @@ static stock Color_GetChatColorInfo(&index, &subject=CHATCOLOR_NOSUBJECT)
 
 	while (!chatColorInfo[index][ChatColorInfo_Supported]) {
 
-		new alternative = chatColorInfo[index][ChatColorInfo_Alternative];
+		int alternative = chatColorInfo[index][ChatColorInfo_Alternative];
 
 		if (alternative == -1) {
 			index = 0;
@@ -475,8 +469,8 @@ static stock Color_GetChatColorInfo(&index, &subject=CHATCOLOR_NOSUBJECT)
 		index = 0;
 	}
 
-	new newSubject = CHATCOLOR_NOSUBJECT;
-	new ChatColorSubjectType:type = chatColorInfo[index][ChatColorInfo_SubjectType];
+	int newSubject = CHATCOLOR_NOSUBJECT;
+	ChatColorSubjectType type = chatColorInfo[index][ChatColorInfo_SubjectType];
 
 	switch (type) {
 
@@ -493,16 +487,16 @@ static stock Color_GetChatColorInfo(&index, &subject=CHATCOLOR_NOSUBJECT)
 		}
 		default: {
 
-			if (!checkTeamPlay || GetConVarBool(mp_teamplay)) {
+			if (!checkTeamPlay || mp_teamplay.BoolValue) {
 
 				if (subject > 0 && subject <= MaxClients) {
 
-					if (GetClientTeam(subject) == _:type) {
+					if (GetClientTeam(subject) == view_as<int>(type)) {
 						newSubject = subject;
 					}
 				}
 				else if (subject == CHATCOLOR_NOSUBJECT) {
-					new client = Team_GetAnyClient(_:type);
+					int client = Team_GetAnyClient(view_as<int>(type));
 
 					if (client != -1) {
 						newSubject = client;

--- a/scripting/include/smlib/concommands.inc
+++ b/scripting/include/smlib/concommands.inc
@@ -13,9 +13,9 @@
  * @param    flags        Flags to check.
  * @return                True if flags are set, false otherwise.
  */
-stock bool:ConCommand_HasFlags(const String:command[], const flags)
+stock bool ConCommand_HasFlags(const char[] command, const int flags)
 {
-    return bool:(GetCommandFlags(command) & flags);
+    return view_as<bool>(GetCommandFlags(command) & flags);
 }
 
 /**
@@ -25,9 +25,9 @@ stock bool:ConCommand_HasFlags(const String:command[], const flags)
  * @param    flags        Flags to add.
  * @noreturn
  */
-stock ConCommand_AddFlags(const String:command[], const flags)
+stock void ConCommand_AddFlags(const char[] command, const int flags)
 {
-    new newFlags = GetCommandFlags(command);
+    int newFlags = GetCommandFlags(command);
     newFlags |= flags;
     SetCommandFlags(command, newFlags);
 }
@@ -39,9 +39,9 @@ stock ConCommand_AddFlags(const String:command[], const flags)
  * @param    flags        Flags to remove
  * @noreturn
  */
-stock ConCommand_RemoveFlags(const String:command[], const flags)
+stock void ConCommand_RemoveFlags(const char[] command, const int flags)
 {
-    new newFlags = GetCommandFlags(command);
+    int newFlags = GetCommandFlags(command);
     newFlags &= ~flags;
     SetCommandFlags(command, newFlags);
 }

--- a/scripting/include/smlib/convars.inc
+++ b/scripting/include/smlib/convars.inc
@@ -12,9 +12,9 @@
  * @param	flags		Flags to check.
  * @return				True if flags are set, false otherwise.
  */
-stock bool:Convar_HasFlags(Handle:convar, flags)
+stock bool Convar_HasFlags(ConVar convar, int flags)
 {
-	return bool:(GetConVarFlags(convar) & flags);
+	return view_as<bool>(convar.Flags & flags);
 }
 
 /**
@@ -24,11 +24,11 @@ stock bool:Convar_HasFlags(Handle:convar, flags)
  * @param	flags		Flags to add.
  * @noreturn
  */
-stock Convar_AddFlags(Handle:convar, flags)
+stock void Convar_AddFlags(ConVar convar, int flags)
 {
-	new newFlags = GetConVarFlags(convar);
+	int newFlags = convar.Flags;
 	newFlags |= flags;
-	SetConVarFlags(convar, newFlags);
+	convar.Flags = newFlags;
 }
 
 /**
@@ -38,11 +38,11 @@ stock Convar_AddFlags(Handle:convar, flags)
  * @param	flags		Flags to remove
  * @noreturn
  */
-stock Convar_RemoveFlags(Handle:convar, flags)
+stock void Convar_RemoveFlags(ConVar convar, int flags)
 {
-	new newFlags = GetConVarFlags(convar);
+	int newFlags = convar.Flags;
 	newFlags &= ~flags;
-	SetConVarFlags(convar, newFlags);
+	convar.Flags = newFlags;
 }
 
 /**
@@ -52,13 +52,13 @@ stock Convar_RemoveFlags(Handle:convar, flags)
  * @param	name		String Name.
  * @return				True if the name specified is a valid ConVar or console command name, false otherwise.
  */
-stock bool:Convar_IsValidName(const String:name[])
+stock bool Convar_IsValidName(const char[] name)
 {
 	if (name[0] == '\0') {
 		return false;
 	}
 
-	new n=0;
+	int n=0;
 	while (name[n] != '\0') {
 
 		if (!IsValidConVarChar(name[n])) {

--- a/scripting/include/smlib/crypt.inc
+++ b/scripting/include/smlib/crypt.inc
@@ -571,9 +571,9 @@ stock void Crypt_RC4Encode(const char[] input, const char[] pwd, char[] output, 
  * @param pwd			The password/key used to encode and decode the data.
  * @param output		The encoded result.
  * @param maxlen		The maximum length of the output buffer.
- * @noreturn
+ * @return				Number of written bits, -1 if unsuccessful
  */
-stock void Crypt_RC4EncodeBinary(const char[] input, int str_len, const char[] pwd, char[] output, int maxlen)
+stock int Crypt_RC4EncodeBinary(const char[] input, int str_len, const char[] pwd, char[] output, int maxlen)
 {
 	int pwd_len,i,j,a,k;
 	int key[256];

--- a/scripting/include/smlib/crypt.inc
+++ b/scripting/include/smlib/crypt.inc
@@ -14,13 +14,13 @@
  ***********************************************************************************/
 
 // The Base64 encoding table
-static const String:base64_sTable[] =
+static const char base64_sTable[] =
   // 0000000000111111111122222222223333333333444444444455555555556666
   // 0123456789012345678901234567890123456789012345678901234567890123
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 // The Base64 decoding table
-static const base64_decodeTable[] = {
+static const int base64_decodeTable[] = {
 //  0   1   2   3   4   5   6   7   8   9
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,   //   0 -   9
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,   //  10 -  19
@@ -54,11 +54,11 @@ static const base64_decodeTable[] = {
  * For some reason the standard demands a string in 24-bit (3 character) intervals.
  * This fill character is used to identify unused bytes at the end of the string.
  */
-static const base64_cFillChar			= '=';
+static const int base64_cFillChar			= '=';
 
 // The conversion characters between the standard and URL-compliance Base64 protocols
-static const String:base64_mime_chars[]	= "+/=";
-static const String:base64_url_chars[]	= "-_.";
+static const char base64_mime_chars[]	= "+/=";
+static const char base64_url_chars[]	= "-_.";
 
 /*
  * Encodes a string or binary data into Base64
@@ -70,10 +70,10 @@ static const String:base64_url_chars[]	= "-_.";
  *						This is not needed for a text string, but is important for binary data since there is no end-of-line character.
  * @return				The length of the written Base64 string, in bytes.
  */
-stock Crypt_Base64Encode(const String:sString[], String:sResult[], len, sourcelen=0)
+stock int Crypt_Base64Encode(const char[] sString, char[] sResult, int len, int sourcelen=0)
 {
-	new nLength;	// The string length to be read from the input
-	new resPos;		// The string position in the result buffer
+	int nLength;	// The string length to be read from the input
+	int resPos;		// The string position in the result buffer
 
 	// If the read length was specified, use it; otherwise, pull the string length from the input.
 	if (sourcelen > 0) {
@@ -85,8 +85,8 @@ stock Crypt_Base64Encode(const String:sString[], String:sResult[], len, sourcele
 
 	// Loop through and generate the Base64 encoded string
 	// NOTE: This performs the standard encoding process.  Do not manipulate the logic within this loop.
-	for (new nPos = 0; nPos < nLength; nPos++) {
-		new cCode;
+	for (int nPos = 0; nPos < nLength; nPos++) {
+		int cCode;
 
 		cCode = (sString[nPos] >> 2) & 0x3f;
 
@@ -132,16 +132,16 @@ stock Crypt_Base64Encode(const String:sString[], String:sResult[], len, sourcele
  * @param len			The maximum length of the storage buffer, in characters/bytes.
  * @return				The length of the decoded data, in bytes.
  */
-stock Crypt_Base64Decode(const String:sString[], String:sResult[], len)
+stock int Crypt_Base64Decode(const char[] sString, char[] sResult, int len)
 {
-	new nLength = strlen(sString);	// The string length to be read from the input
-	new resPos;						// The string position in the result buffer
+	int nLength = strlen(sString);	// The string length to be read from the input
+	int resPos;						// The string position in the result buffer
 
 	// Loop through and generate the Base64 encoded string
 	// NOTE: This performs the standard encoding process.  Do not manipulate the logic within this loop.
-	for (new nPos = 0; nPos < nLength; nPos++) {
+	for (int nPos = 0; nPos < nLength; nPos++) {
 
-		new c, c1;
+		int c, c1;
 
 		c	= base64_decodeTable[sString[nPos++]];
 		c1	= base64_decodeTable[sString[nPos]];
@@ -190,21 +190,21 @@ stock Crypt_Base64Decode(const String:sString[], String:sResult[], len)
  * @param len			The maximum length of the storage buffer in characters/bytes.
  * @return				Number of cells written.
  */
-stock Crypt_Base64MimeToUrl(const String:sString[], String:sResult[], len)
+stock int Crypt_Base64MimeToUrl(const char[] sString, char[] sResult, int len)
 {
-	new chars_len = sizeof(base64_mime_chars);	// Length of the two standards vs. URL character lists
-	new nLength;								// The string length to be read from the input
-	new temp_char;								// Buffer character
+	int chars_len = sizeof(base64_mime_chars);	// Length of the two standards vs. URL character lists
+	int nLength;								// The string length to be read from the input
+	int temp_char;								// Buffer character
 
 	nLength = strlen(sString);
 
-	new String:sTemp[nLength+1]; // Buffer string
+	char[] sTemp = new char[nLength+1]; // Buffer string
 
 	// Loop through string
-	for (new i = 0; i < nLength; i++) {
+	for (int i = 0; i < nLength; i++) {
 		temp_char = sString[i];
 
-		for (new j = 0; j < chars_len; j++) {
+		for (int j = 0; j < chars_len; j++) {
 
 			if(temp_char == base64_mime_chars[j]) {
 				temp_char = base64_url_chars[j];
@@ -221,7 +221,7 @@ stock Crypt_Base64MimeToUrl(const String:sString[], String:sResult[], len)
 }
 
 /*
- * Base64UrlToMime(String:sResult[], len, const String:sString[], sourcelen)
+ * Base64UrlToMime(char[] sResult, int len, const char[] sString, int sourcelen)
  * Converts a URL-compliant Base64 string to the standards-compliant version.
  * Note: The result will be the same length as the input string as long as the output buffer is large enough.
  *
@@ -230,20 +230,20 @@ stock Crypt_Base64MimeToUrl(const String:sString[], String:sResult[], len)
  * @param len			The maximum length of the storage buffer in characters/bytes.
  * @return				Number of cells written.
  */
-stock Crypt_Base64UrlToMime(const String:sString[], String:sResult[], len)
+stock int Crypt_Base64UrlToMime(const char[] sString, char[] sResult, int len)
 {
-	new chars_len = sizeof(base64_mime_chars);	// Length of the two standards vs. URL character lists
-	new nLength;								// The string length to be read from the input
-	new temp_char;								// Buffer character
+	int chars_len = sizeof(base64_mime_chars);	// Length of the two standards vs. URL character lists
+	int nLength;								// The string length to be read from the input
+	int temp_char;								// Buffer character
 
 	nLength = strlen(sString);
 
-	new String:sTemp[nLength+1]; // Buffer string
+	char[] sTemp = new char[nLength+1]; // Buffer string
 
 	// Loop through string
-	for (new i = 0; i < nLength; i++) {
+	for (int i = 0; i < nLength; i++) {
 		temp_char = sString[i];
-		for (new j = 0; j < chars_len; j++) {
+		for (int j = 0; j < chars_len; j++) {
 			if (temp_char == base64_url_chars[j]) {
 				temp_char = base64_mime_chars[j];
 				break;
@@ -275,14 +275,14 @@ stock Crypt_Base64UrlToMime(const String:sString[], String:sResult[], len)
  * @param maxlen		Size of the Output String Buffer
  * @noreturn
  */
-stock Crypt_MD5(const String:str[], String:output[], maxlen)
+stock void Crypt_MD5(const char[] str, char[] output, int maxlen)
 {
-	decl x[2];
-	decl buf[4];
-	decl input[64];
-	new i, ii;
+	int x[2];
+	int buf[4];
+	int input[64];
+	int i, ii;
 
-	new len = strlen(str);
+	int len = strlen(str);
 
 	// MD5Init
 	x[0] = x[1] = 0;
@@ -292,12 +292,12 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 	buf[3] = 0x10325476;
 
 	// MD5Update
-	new update[16];
+	int update[16];
 
 	update[14] = x[0];
 	update[15] = x[1];
 
-	new mdi = (x[0] >>> 3) & 0x3F;
+	int mdi = (x[0] >>> 3) & 0x3F;
 
 	if ((x[0] + (len << 3)) < x[0]) {
 		x[1] += 1;
@@ -306,7 +306,7 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 	x[0] += len << 3;
 	x[1] += len >>> 29;
 
-	new c = 0;
+	int c = 0;
 	while (len--) {
 		input[mdi] = str[c];
 		mdi += 1;
@@ -327,7 +327,7 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 	}
 
 	// MD5Final
-	new padding[64] = {
+	int padding[64] = {
 		0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -338,7 +338,7 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
 
-	new inx[16];
+	int inx[16];
 	inx[14] = x[0];
 	inx[15] = x[1];
 
@@ -382,7 +382,7 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 
 	MD5Transform(buf, inx);
 
-	new digest[16];
+	int digest[16];
 	for (i = 0, ii = 0; i < 4; ++i, ii += 4) {
 		digest[ii] = (buf[i]) & 0xFF;
 		digest[ii + 1] = (buf[i] >>> 8) & 0xFF;
@@ -395,39 +395,39 @@ stock Crypt_MD5(const String:str[], String:output[], maxlen)
 		digest[8], digest[9], digest[10], digest[11], digest[12], digest[13], digest[14], digest[15]);
 }
 
-static stock MD5Transform_FF(&a, &b, &c, &d, x, s, ac)
-	{
+static stock void MD5Transform_FF(int &a, int &b, int &c, int &d, int x, int s, int ac)
+{
 	a += (((b) & (c)) | ((~b) & (d))) + x + ac;
 	a = (((a) << (s)) | ((a) >>> (32-(s))));
 	a += b;
 }
 
-static stock MD5Transform_GG(&a, &b, &c, &d, x, s, ac)
-	{
+static stock void MD5Transform_GG(int &a, int &b, int &c, int &d, int x, int s, int ac)
+{
 	a += (((b) & (d)) | ((c) & (~d))) + x + ac;
 	a = (((a) << (s)) | ((a) >>> (32-(s))));
 	a += b;
 }
 
-static stock MD5Transform_HH(&a, &b, &c, &d, x, s, ac)
-	{
+static stock void MD5Transform_HH(int &a, int &b, int &c, int &d, int x, int s, int ac)
+{
 	a += ((b) ^ (c) ^ (d)) + x + ac;
 	a = (((a) << (s)) | ((a) >>> (32-(s))));
 	a += b;
 }
 
-static stock MD5Transform_II(&a, &b, &c, &d, x, s, ac)
+static stock void MD5Transform_II(int &a, int &b, int &c, int &d, int x, int s, int ac)
 {
 	a += ((c) ^ ((b) | (~d))) + x + ac;
 	a = (((a) << (s)) | ((a) >>> (32-(s))));
 	a += b;
 }
 
-static stock MD5Transform(buf[], input[]){
-	new a = buf[0];
-	new b = buf[1];
-	new c = buf[2];
-	new d = buf[3];
+static stock void MD5Transform(int[] buf, int[] input){
+	int a = buf[0];
+	int b = buf[1];
+	int c = buf[2];
+	int d = buf[3];
 
 	MD5Transform_FF(a, b, c, d, input[0], 7, 0xd76aa478);
 	MD5Transform_FF(d, a, b, c, input[1], 12, 0xe8c7b756);
@@ -523,12 +523,12 @@ static stock MD5Transform(buf[], input[]){
  *
  * @noreturn
  */
-stock Crypt_RC4Encode(const String:input[], const String:pwd[], String:output[], maxlen)
+stock void Crypt_RC4Encode(const char[] input, const char[] pwd, char[] output, int maxlen)
 {
-	decl pwd_len,str_len,i,j,a,k;
-	decl key[256];
-	decl box[256];
-	decl tmp;
+	int pwd_len,str_len,i,j,a,k;
+	int key[256];
+	int box[256];
+	int tmp;
 
 	pwd_len = strlen(pwd);
 	str_len = strlen(input);
@@ -573,12 +573,12 @@ stock Crypt_RC4Encode(const String:input[], const String:pwd[], String:output[],
  * @param maxlen		The maximum length of the output buffer.
  * @noreturn
  */
-stock Crypt_RC4EncodeBinary(const String:input[], str_len, const String:pwd[], String:output[], maxlen)
+stock void Crypt_RC4EncodeBinary(const char[] input, int str_len, const char[] pwd, char[] output, int maxlen)
 {
-	decl pwd_len,i,j,a,k;
-	decl key[256];
-	decl box[256];
-	decl tmp;
+	int pwd_len,i,j,a,k;
+	int key[256];
+	int box[256];
+	int tmp;
 
 	pwd_len = strlen(pwd);
 

--- a/scripting/include/smlib/debug.inc
+++ b/scripting/include/smlib/debug.inc
@@ -12,11 +12,11 @@
  * @param size		Size of the Array.
  * @noreturn
  */
-stock Debug_FloatArray(const Float:array[], size=3)
+stock void Debug_FloatArray(const float[] array, int size=3)
 {
-	new String:output[64] = "";
+	char output[64] = "";
 
-	for (new i=0; i < size; ++i) {
+	for (int i=0; i < size; ++i) {
 
 		if (i > 0 && i < size) {
 			StrCat(output, sizeof(output), ", ");

--- a/scripting/include/smlib/dynarrays.inc
+++ b/scripting/include/smlib/dynarrays.inc
@@ -10,15 +10,15 @@
  * This is a wrapper around the Sourcemod Function GetArrayCell,
  * but it casts the result as bool
  *
- * @param array			Array Handle.
+ * @param array			ArrayList.
  * @param index			Index in the array.
  * @param block			Optionally specify which block to read from
  *						(useful if the blocksize > 0).
  * @param asChar		Optionally read as a byte instead of a cell.
  * @return				Value read.
- * @error				Invalid Handle, invalid index, or invalid block.
+ * @error				Invalid array, invalid index, or invalid block.
  */
-stock bool:DynArray_GetBool(Handle:array, index, block=0, bool:asChar=false)
+stock bool DynArray_GetBool(ArrayList array, int index, int block=0, bool asChar=false)
 {
-	return bool:GetArrayCell(array, index, block, asChar);
+	return view_as<bool>(array.Get(index, block, asChar));
 }

--- a/scripting/include/smlib/edicts.inc
+++ b/scripting/include/smlib/edicts.inc
@@ -13,10 +13,10 @@
  * @param name			Name of the entity you want so search.
  * @return				Edict Index or INVALID_ENT_REFERENCE if no entity was found.
  */
-stock Edict_FindByName(const String:name[])
+stock int Edict_FindByName(const char[] name)
 {
-	new maxEntities = GetMaxEntities();
-	for (new edict=0; edict < maxEntities; edict++) {
+	int maxEntities = GetMaxEntities();
+	for (int edict=0; edict < maxEntities; edict++) {
 
 		if (!IsValidEdict(edict)) {
 			continue;
@@ -39,10 +39,10 @@ stock Edict_FindByName(const String:name[])
  * @param hammerId		Hammer editor ID
  * @return				Edict Index or INVALID_ENT_REFERENCE if no entity was found.
  */
-stock Edict_FindByHammerId(hammerId)
+stock int Edict_FindByHammerId(int hammerId)
 {
-	new maxEntities = GetMaxEntities();
-	for (new edict=0; edict < maxEntities; edict++) {
+	int maxEntities = GetMaxEntities();
+	for (int edict=0; edict < maxEntities; edict++) {
 
 		if (!IsValidEdict(edict)) {
 			continue;
@@ -64,13 +64,13 @@ stock Edict_FindByHammerId(hammerId)
  * @param ignoreEntity		Ignore this entity
  * @return					Edict Index or INVALID_ENT_REFERENCE if no entity was found.
  */
-stock Edict_GetClosest(Float:vecOrigin_center[3], bool:clientsOnly=false, ignoreEntity=-1)
+stock int Edict_GetClosest(float vecOrigin_center[3], bool clientsOnly=false, int ignoreEntity=-1)
 {
-	decl Float:vecOrigin_edict[3];
-	new Float:smallestDistance = 0.0;
-	new closestEdict = INVALID_ENT_REFERENCE;
+	float vecOrigin_edict[3];
+	float smallestDistance = 0.0;
+	int closestEdict = INVALID_ENT_REFERENCE;
 
-	new maxEntities;
+	int maxEntities;
 
 	if (clientsOnly) {
 		maxEntities = MaxClients;
@@ -79,7 +79,7 @@ stock Edict_GetClosest(Float:vecOrigin_center[3], bool:clientsOnly=false, ignore
 		maxEntities = GetMaxEntities();
 	}
 
-	for (new edict=1; edict <= maxEntities; edict++) {
+	for (int edict=1; edict <= maxEntities; edict++) {
 
 		if (!IsValidEdict(edict)) {
 			continue;
@@ -95,7 +95,7 @@ stock Edict_GetClosest(Float:vecOrigin_center[3], bool:clientsOnly=false, ignore
 
 		Entity_GetAbsOrigin(edict, vecOrigin_edict);
 
-		new Float:edict_distance = GetVectorDistance(vecOrigin_center, vecOrigin_edict, true);
+		float edict_distance = GetVectorDistance(vecOrigin_center, vecOrigin_edict, true);
 
 		if (edict_distance < smallestDistance || smallestDistance == 0.0) {
 			smallestDistance = edict_distance;
@@ -113,9 +113,9 @@ stock Edict_GetClosest(Float:vecOrigin_center[3], bool:clientsOnly=false, ignore
  * @param clientsOnly		True if you only want to search for clients
  * @return					The closest edict or INVALID_ENT_REFERENCE
  */
-stock Edict_GetClosestToEdict(edict, bool:clientsOnly=false)
+stock int Edict_GetClosestToEdict(int edict, bool clientsOnly=false)
 {
-	decl Float:vecOrigin[3];
+	float vecOrigin[3];
 
 	if (GetEntSendPropOffs(edict, "m_vecOrigin") == -1) {
 		return INVALID_ENT_REFERENCE;

--- a/scripting/include/smlib/effects.inc
+++ b/scripting/include/smlib/effects.inc
@@ -598,7 +598,7 @@ stock void Effect_DrawAxisOfRotationToAll(
 	int speed=0
 )
 {
-	int clients[MaxClients];
+	int[] clients = new int[MaxClients];
 	int numClients = Client_Get(clients, CLIENTFILTER_INGAME);
 
 	Effect_DrawAxisOfRotation(clients, numClients, origin, angles, length, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, speed);
@@ -688,7 +688,7 @@ stock void Effect_DrawAxisOfRotation(
  * @return					Entity Index of the created Sprite.
  */
 stock int Effect_EnvSprite(
-	const float origin[3],
+	float origin[3],
 	int modelIndex,
 	const int color[4]={255, 255, 255, 255},
 	float scale=0.25,

--- a/scripting/include/smlib/effects.inc
+++ b/scripting/include/smlib/effects.inc
@@ -31,16 +31,16 @@ enum DissolveType
  * @param magnitude		How strongly to push away from the center.
  * @return				True on success, otherwise false.
  */
-stock bool:Effect_DissolveEntity(entity, DissolveType:dissolveType=DISSOLVE_NORMAL, magnitude=1)
+stock bool Effect_DissolveEntity(int entity, DissolveType dissolveType=DISSOLVE_NORMAL, int magnitude=1)
 {
-	new env_entity_dissolver = CreateEntityByName("env_entity_dissolver");
+	int env_entity_dissolver = CreateEntityByName("env_entity_dissolver");
 
 	if (env_entity_dissolver == -1) {
 		return false;
 	}
 
 	Entity_PointAtTarget(env_entity_dissolver, entity);
-	SetEntProp(env_entity_dissolver, Prop_Send, "m_nDissolveType", _:dissolveType);
+	SetEntProp(env_entity_dissolver, Prop_Send, "m_nDissolveType", view_as<int>(dissolveType));
 	SetEntProp(env_entity_dissolver, Prop_Send, "m_nMagnitude", magnitude);
 	AcceptEntityInput(env_entity_dissolver,	"Dissolve");
 	Entity_Kill(env_entity_dissolver);
@@ -55,9 +55,9 @@ stock bool:Effect_DissolveEntity(entity, DissolveType:dissolveType=DISSOLVE_NORM
  * @param dissolveType	Dissolve Type, use the DissolveType enum.
  * @return				True on success, otherwise false.
  */
-stock bool:Effect_DissolvePlayerRagDoll(client, DissolveType:dissolveType=DISSOLVE_NORMAL)
+stock bool Effect_DissolvePlayerRagDoll(int client, DissolveType dissolveType=DISSOLVE_NORMAL)
 {
-	new m_hRagdoll = GetEntPropEnt(client, Prop_Send, "m_hRagdoll");
+	int m_hRagdoll = GetEntPropEnt(client, Prop_Send, "m_hRagdoll");
 
 	if (m_hRagdoll == -1) {
 		return false;
@@ -66,7 +66,7 @@ stock bool:Effect_DissolvePlayerRagDoll(client, DissolveType:dissolveType=DISSOL
 	return Effect_DissolveEntity(m_hRagdoll, dissolveType);
 }
 
-functag EffectCallback public(entity, any:data);
+typedef EffectCallback = function void (int entity, any data);
 
 /**
  * Fades an entity in our out.
@@ -82,11 +82,11 @@ functag EffectCallback public(entity, any:data);
  * @param fast			Optional: Fade the entity fast (~0.7 secs) or slow (~3 secs)
  * @param callback		Optional: You can specify a callback Function that will get called when the fade is finished.
  * @param data			Optional: You can pass any data to the callback.
- * @return				True on success, otherwise false.
+ * @noreturn
  */
-stock Effect_Fade(entity, fadeOut=true, kill=false, fast=true, EffectCallback:callback=INVALID_FUNCTION, any:data=0)
+stock void Effect_Fade(int entity, bool fadeOut=true, bool kill=false, bool fast=true, EffectCallback callback=INVALID_FUNCTION, any data=0)
 {
-	new Float:timerTime = 0.0;
+	float timerTime = 0.0;
 
 	if (fast) {
 		timerTime = 0.6;
@@ -112,18 +112,14 @@ stock Effect_Fade(entity, fadeOut=true, kill=false, fast=true, EffectCallback:ca
 	ChangeEdictState(entity, GetEntSendPropOffs(entity, "m_nRenderFX", true));
 
 	if (kill || callback != INVALID_FUNCTION) {
-		new Handle:dataPack = INVALID_HANDLE;
+		DataPack dataPack;
 		CreateDataTimer(timerTime, _smlib_Timer_Effect_Fade, dataPack, TIMER_FLAG_NO_MAPCHANGE | TIMER_DATA_HNDL_CLOSE);
 
-		WritePackCell(dataPack, EntIndexToEntRef(entity));
-		WritePackCell(dataPack, kill);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-		WritePackFunction(dataPack, callback);
-#else
-		WritePackCell(dataPack, _:callback);
-#endif
-		WritePackCell(dataPack, data);
-		ResetPack(dataPack);
+		dataPack.WriteCell(EntIndexToEntRef(entity));
+		dataPack.WriteCell(kill);
+		dataPack.WriteFunction(callback);
+		dataPack.WriteCell(data);
+		dataPack.Reset();
 	}
 }
 
@@ -135,9 +131,9 @@ stock Effect_Fade(entity, fadeOut=true, kill=false, fast=true, EffectCallback:ca
  * @param fast			Optional: Fade the entity fast (~0.7 secs) or slow (~3 secs)
  * @param callback		Optional: You can specify a callback Function that will get called when the fade is finished.
  * @param data			Optional: You can pass any data to the callback.
- * @return				True on success, otherwise false.
+ * @noreturn
  */
-stock Effect_FadeIn(entity, fast=true, EffectCallback:callback=INVALID_FUNCTION, any:data=0)
+stock void Effect_FadeIn(int entity, bool fast=true, EffectCallback callback=INVALID_FUNCTION, any data=0)
 {
 	Effect_Fade(entity, false, false, fast, callback, data);
 }
@@ -152,26 +148,23 @@ stock Effect_FadeIn(entity, fast=true, EffectCallback:callback=INVALID_FUNCTION,
  * @param fast			Optional: Fade the entity fast (~0.7 secs) or slow (~3 secs)
  * @param callback		Optional: You can specify a callback Function that will get called when the fade is finished.
  * @param data			Optional: You can pass any data to the callback.
- * @return				True on success, otherwise false.
+ * @noreturn
  */
-stock Effect_FadeOut(entity, kill=false, fast=true, EffectCallback:callback=INVALID_FUNCTION, any:data=0)
+stock void Effect_FadeOut(int entity, bool kill=false, bool fast=true, EffectCallback callback=INVALID_FUNCTION, any data=0)
 {
 	Effect_Fade(entity, true, kill, fast, callback, data);
 }
 
-public Action:_smlib_Timer_Effect_Fade(Handle:Timer, Handle:dataPack)
+public Action _smlib_Timer_Effect_Fade(Handle timer, DataPack dataPack)
 {
-	new entity = ReadPackCell(dataPack);
-	new kill = ReadPackCell(dataPack);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	new Function:callback = ReadPackFunction(dataPack);
-#else
-	new Function:callback = Function:ReadPackCell(dataPack);
-#endif
-	new any:data = any:ReadPackCell(dataPack);
+	dataPack.Reset();
+	int entity = dataPack.ReadCell();
+	int kill = dataPack.ReadCell();
+	Function callback = view_as<Function>(dataPack.ReadFunction());
+	any data = view_as<any>(dataPack.ReadCell());
 
 	if (callback != INVALID_FUNCTION) {
-		Call_StartFunction(INVALID_HANDLE, callback);
+		Call_StartFunction(null, callback);
 		Call_PushCell(entity);
 		Call_PushCell(data);
 		Call_Finish();
@@ -205,23 +198,23 @@ public Action:_smlib_Timer_Effect_Fade(Handle:Timer, Handle:dataPack)
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawBeamBoxToClient(
-	client,
-	const Float:bottomCorner[3],
-	const Float:upperCorner[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	const color[4]={ 255, 0, 0, 255 },
-	speed=0
+stock void Effect_DrawBeamBoxToClient(
+	int client,
+	const float bottomCorner[3],
+	const float upperCorner[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	const int color[4]={ 255, 0, 0, 255 },
+	int speed=0
 ) {
-    new clients[1];
+    int clients[1];
     clients[0] = client;
     Effect_DrawBeamBox(clients, 1, bottomCorner, upperCorner, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 }
@@ -246,24 +239,24 @@ stock Effect_DrawBeamBoxToClient(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawBeamBoxToAll(
-	const Float:bottomCorner[3],
-	const Float:upperCorner[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	const color[4]={ 255, 0, 0, 255 },
-	speed=0
+stock void Effect_DrawBeamBoxToAll(
+	const float bottomCorner[3],
+	const float upperCorner[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	const int color[4]={ 255, 0, 0, 255 },
+	int speed=0
 )
 {
-	new clients[MaxClients];
-	new numClients = Client_Get(clients, CLIENTFILTER_INGAME);
+	int[] clients = new int[MaxClients];
+	int numClients = Client_Get(clients, CLIENTFILTER_INGAME);
 
 	Effect_DrawBeamBox(clients, numClients, bottomCorner, upperCorner, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 }
@@ -290,27 +283,27 @@ stock Effect_DrawBeamBoxToAll(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawBeamBox(
-	clients[],
-	numClients,
-	const Float:bottomCorner[3],
-	const Float:upperCorner[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	const color[4]={ 255, 0, 0, 255 },
-	speed=0
+stock void Effect_DrawBeamBox(
+	int[] clients,
+	int numClients,
+	const float bottomCorner[3],
+	const float upperCorner[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	const int color[4]={ 255, 0, 0, 255 },
+	int speed=0
 ) {
 	// Create the additional corners of the box
-	decl Float:corners[8][3];
+	float corners[8][3];
 
-	for (new i=0; i < 4; i++) {
+	for (int i=0; i < 4; i++) {
 		Array_Copy(bottomCorner,	corners[i],		3);
 		Array_Copy(upperCorner,		corners[i+4],	3);
 	}
@@ -328,26 +321,25 @@ stock Effect_DrawBeamBox(
 
 	// Horizontal Lines
 	// Bottom
-	for (new i=0; i < 4; i++) {
-		new j = ( i == 3 ? 0 : i+1 );
+	for (int i=0; i < 4; i++) {
+		int j = ( i == 3 ? 0 : i+1 );
 		TE_SetupBeamPoints(corners[i], corners[j], modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 		TE_Send(clients, numClients);
 	}
 
 	// Top
-	for (new i=4; i < 8; i++) {
-		new j = ( i == 7 ? 4 : i+1 );
+	for (int i=4; i < 8; i++) {
+		int j = ( i == 7 ? 4 : i+1 );
 		TE_SetupBeamPoints(corners[i], corners[j], modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 		TE_Send(clients, numClients);
 	}
 
 	// All Vertical Lines
-	for (new i=0; i < 4; i++) {
+	for (int i=0; i < 4; i++) {
 		TE_SetupBeamPoints(corners[i], corners[i+4], modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 		TE_Send(clients, numClients);
 	}
 }
-
 
 /**
  * Sends a boxed beam effect to one player.
@@ -372,25 +364,25 @@ stock Effect_DrawBeamBox(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawBeamBoxRotatableToClient(
-	client,
-	const Float:origin[3],
-	const Float:mins[3],
-	const Float:maxs[3],
-	const Float:angles[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	const color[4]={ 255, 0, 0, 255 },
-	speed=0
+stock void Effect_DrawBeamBoxRotatableToClient(
+	int client,
+	const float origin[3],
+	const float mins[3],
+	const float maxs[3],
+	const float angles[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	const int color[4]={ 255, 0, 0, 255 },
+	int speed=0
 ) {
-    new clients[1];
+    int clients[1];
     clients[0] = client;
     Effect_DrawBeamBoxRotatable(clients, 1, origin, mins, maxs, angles, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 }
@@ -419,26 +411,26 @@ stock Effect_DrawBeamBoxRotatableToClient(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawBeamBoxRotatableToAll(
-	const Float:origin[3],
-	const Float:mins[3],
-	const Float:maxs[3],
-	const Float:angles[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	const color[4]={ 255, 0, 0, 255 },
-	speed=0
+stock void Effect_DrawBeamBoxRotatableToAll(
+	const float origin[3],
+	const float mins[3],
+	const float maxs[3],
+	const float angles[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	const int color[4]={ 255, 0, 0, 255 },
+	int speed=0
 )
 {
-	new clients[MaxClients];
-	new numClients = Client_Get(clients, CLIENTFILTER_INGAME);
+	int[] clients = new int[MaxClients];
+	int numClients = Client_Get(clients, CLIENTFILTER_INGAME);
 
 	Effect_DrawBeamBoxRotatable(clients, numClients, origin, mins, maxs, angles, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 }
@@ -467,27 +459,27 @@ stock Effect_DrawBeamBoxRotatableToAll(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawBeamBoxRotatable(
-	clients[],
-	numClients,
-	const Float:origin[3],
-	const Float:mins[3],
-	const Float:maxs[3],
-	const Float:angles[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	const color[4]={ 255, 0, 0, 255 },
-	speed=0
+stock void Effect_DrawBeamBoxRotatable(
+	int[] clients,
+	int numClients,
+	const float origin[3],
+	const float mins[3],
+	const float maxs[3],
+	const float angles[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	const int color[4]={ 255, 0, 0, 255 },
+	int speed=0
 ) {
 	// Create the additional corners of the box
-	decl Float:corners[8][3];
+	float corners[8][3];
 	Array_Copy(mins, corners[0], 3);
 	Math_MakeVector(maxs[0], mins[1], mins[2], corners[1]);
 	Math_MakeVector(maxs[0], maxs[1], mins[2], corners[2]);
@@ -498,33 +490,33 @@ stock Effect_DrawBeamBoxRotatable(
 	Math_MakeVector(mins[0], maxs[1], maxs[2], corners[7]);
 
 	// Rotate all edges
-	for (new i=0; i < sizeof(corners); i++) {
+	for (int i=0; i < sizeof(corners); i++) {
 		Math_RotateVector(corners[i], angles, corners[i]);
 	}
 
 	// Apply world offset (after rotation)
-	for (new i=0; i < sizeof(corners); i++) {
+	for (int i=0; i < sizeof(corners); i++) {
 		AddVectors(origin, corners[i], corners[i]);
 	}
 
     // Draw all the edges
 	// Horizontal Lines
 	// Bottom
-	for (new i=0; i < 4; i++) {
-		new j = ( i == 3 ? 0 : i+1 );
+	for (int i=0; i < 4; i++) {
+		int j = ( i == 3 ? 0 : i+1 );
 		TE_SetupBeamPoints(corners[i], corners[j], modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 		TE_Send(clients, numClients);
 	}
 
 	// Top
-	for (new i=4; i < 8; i++) {
-		new j = ( i == 7 ? 4 : i+1 );
+	for (int i=4; i < 8; i++) {
+		int j = ( i == 7 ? 4 : i+1 );
 		TE_SetupBeamPoints(corners[i], corners[j], modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 		TE_Send(clients, numClients);
 	}
 
 	// All Vertical Lines
-	for (new i=0; i < 4; i++) {
+	for (int i=0; i < 4; i++) {
 		TE_SetupBeamPoints(corners[i], corners[i+4], modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, color, speed);
 		TE_Send(clients, numClients);
 	}
@@ -550,23 +542,23 @@ stock Effect_DrawBeamBoxRotatable(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawAxisOfRotationToClient(
-	client,
-	const Float:origin[3],
-	const Float:angles[3],
-	const Float:length[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	speed=0
+stock void Effect_DrawAxisOfRotationToClient(
+	int client,
+	const float origin[3],
+	const float angles[3],
+	const float length[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	int speed=0
 ) {
-    new clients[1];
+    int clients[1];
     clients[0] = client;
     Effect_DrawAxisOfRotation(clients, 1, origin, angles, length, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, speed);
 }
@@ -590,24 +582,24 @@ stock Effect_DrawAxisOfRotationToClient(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawAxisOfRotationToAll(
-	const Float:origin[3],
-	const Float:angles[3],
-	const Float:length[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	speed=0
+stock void Effect_DrawAxisOfRotationToAll(
+	const float origin[3],
+	const float angles[3],
+	const float length[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	int speed=0
 )
 {
-	new clients[MaxClients];
-	new numClients = Client_Get(clients, CLIENTFILTER_INGAME);
+	int clients[MaxClients];
+	int numClients = Client_Get(clients, CLIENTFILTER_INGAME);
 
 	Effect_DrawAxisOfRotation(clients, numClients, origin, angles, length, modelIndex, haloIndex, startFrame, frameRate, life, width, endWidth, fadeLength, amplitude, speed);
 }
@@ -633,25 +625,25 @@ stock Effect_DrawAxisOfRotationToAll(
  * @param speed			Speed of the beam.
  * @noreturn
  */
-stock Effect_DrawAxisOfRotation(
-	clients[],
-	numClients,
-	const Float:origin[3],
-	const Float:angles[3],
-	const Float:length[3],
-	modelIndex,
-	haloIndex,
-	startFrame=0,
-	frameRate=30,
-	Float:life=5.0,
-	Float:width=5.0,
-	Float:endWidth=5.0,
-	fadeLength=2,
-	Float:amplitude=1.0,
-	speed=0
+stock void Effect_DrawAxisOfRotation(
+	int[] clients,
+	int numClients,
+	const float origin[3],
+	const float angles[3],
+	const float length[3],
+	int modelIndex,
+	int haloIndex,
+	int startFrame=0,
+	int frameRate=30,
+	float life=5.0,
+	float width=5.0,
+	float endWidth=5.0,
+	int fadeLength=2,
+	float amplitude=1.0,
+	int speed=0
 ) {
 	// Create the additional corners of the box
-	new Float:xAxis[3], Float:yAxis[3], Float:zAxis[3];
+	float xAxis[3], yAxis[3], zAxis[3];
 	xAxis[0] = length[0];
 	yAxis[1] = length[1];
 	zAxis[2] = length[2];
@@ -695,21 +687,21 @@ stock Effect_DrawAxisOfRotation(
  * @param receiveShadows	When false then this prevents the sprite from receiving shadows.
  * @return					Entity Index of the created Sprite.
  */
-stock Effect_EnvSprite(
-	const Float:origin[3],
-	modelIndex,
-	const color[4]={255, 255, 255, 255},
-	Float:scale=0.25,
-	const String:targetName[MAX_NAME_LENGTH]="",
-	parent=-1,
-	RenderMode:renderMode=RENDER_WORLDGLOW,
-	RenderFx:renderFx=RENDERFX_NONE,
-	Float:glowProxySize=2.0,
-	Float:framerate=10.0,
-	Float:hdrColorScale=1.0,
-	bool:receiveShadows = true
+stock int Effect_EnvSprite(
+	const float origin[3],
+	int modelIndex,
+	const int color[4]={255, 255, 255, 255},
+	float scale=0.25,
+	const char targetName[MAX_NAME_LENGTH]="",
+	int parent=-1,
+	RenderMode renderMode=RENDER_WORLDGLOW,
+	RenderFx renderFx=RENDERFX_NONE,
+	float glowProxySize=2.0,
+	float framerate=10.0,
+	float hdrColorScale=1.0,
+	bool receiveShadows = true
 ) {
-	new entity = Entity_Create("env_sprite");
+	int entity = Entity_Create("env_sprite");
 
 	if (entity == INVALID_ENT_REFERENCE) {
 		return INVALID_ENT_REFERENCE;

--- a/scripting/include/smlib/entities.inc
+++ b/scripting/include/smlib/entities.inc
@@ -13,7 +13,7 @@
  * @param 1		Entity Index of the parent.
  * @param 2		Name of the children entity index variable (will be only valid in the loop).
  */
-#define LOOP_CHILDREN(%1,%2) for (new %2=Entity_GetNextChild(%1); %2 != INVALID_ENT_REFERENCE; %2=Entity_GetNextChild(%1, ++%2))
+#define LOOP_CHILDREN(%1,%2) for (int %2=Entity_GetNextChild(%1); %2 != INVALID_ENT_REFERENCE; %2=Entity_GetNextChild(%1, ++%2))
 
 /*
  * Checks if an entity is valid and exists.
@@ -21,7 +21,7 @@
  * @param entity		Entity Index.
  * @return				True if the entity is valid, false otherwise.
  */
-stock Entity_IsValid(entity)
+stock bool Entity_IsValid(int entity)
 {
 	return IsValidEntity(entity);
 }
@@ -38,12 +38,12 @@ stock Entity_IsValid(entity)
  * @param className		Optional: Classname of the entity
  * @return				Entity index or INVALID_ENT_REFERENCE if not matching entity was found.
  */
-stock Entity_FindByName(const String:name[], const String:className[]="")
+stock int Entity_FindByName(const char[] name, const char className[]="")
 {
 	if (className[0] == '\0') {
 		// Hack: Double the limit to gets none-networked entities too.
-		new realMaxEntities = GetMaxEntities() * 2;
-		for (new entity=0; entity < realMaxEntities; entity++) {
+		int realMaxEntities = GetMaxEntities() * 2;
+		for (int entity=0; entity < realMaxEntities; entity++) {
 
 			if (!IsValidEntity(entity)) {
 				continue;
@@ -55,7 +55,7 @@ stock Entity_FindByName(const String:name[], const String:className[]="")
 		}
 	}
 	else {
-		new entity = INVALID_ENT_REFERENCE;
+		int entity = INVALID_ENT_REFERENCE;
 		while ((entity = FindEntityByClassname(entity, className)) != INVALID_ENT_REFERENCE) {
 
 			if (Entity_NameMatches(entity, name)) {
@@ -81,12 +81,12 @@ stock Entity_FindByName(const String:name[], const String:className[]="")
  * @param className		Optional: Classname of the entity
  * @return				Edict Index or INVALID_ENT_REFERENCE if no entity was found.
  */
-stock Entity_FindByHammerId(hammerId, const String:className[]="")
+stock int Entity_FindByHammerId(int hammerId, const char className[]="")
 {
 	if (className[0] == '\0') {
 		// Hack: Double the limit to gets none-networked entities too.
-		new realMaxEntities = GetMaxEntities() * 2;
-		for (new entity=0; entity < realMaxEntities; entity++) {
+		int realMaxEntities = GetMaxEntities() * 2;
+		for (int entity=0; entity < realMaxEntities; entity++) {
 
 			if (!IsValidEntity(entity)) {
 				continue;
@@ -98,7 +98,7 @@ stock Entity_FindByHammerId(hammerId, const String:className[]="")
 		}
 	}
 	else {
-		new entity = INVALID_ENT_REFERENCE;
+		int entity = INVALID_ENT_REFERENCE;
 		while ((entity = FindEntityByClassname(entity, className)) != INVALID_ENT_REFERENCE) {
 
 			if (Entity_GetHammerId(entity) == hammerId) {
@@ -119,8 +119,7 @@ stock Entity_FindByHammerId(hammerId, const String:className[]="")
  * @param classname		Classname of the entity to find.
  * @return				Entity index >= 0 if found, -1 otherwise.
  */
-
-stock Entity_FindByClassName(startEntity, const String:className[])
+stock int Entity_FindByClassName(int startEntity, const char[] className)
 {
 	return FindEntityByClassname(startEntity, className);
 }
@@ -130,12 +129,12 @@ stock Entity_FindByClassName(startEntity, const String:className[])
  *
  * @param entity		Entity Index.
  * @param className		Classname String.
- * @partialMatch		If to do a partial classname check.
+ * @param partialMatch	If to do a partial classname check.
  * @return				True if the classname matches, false otherwise.
  */
-stock bool:Entity_ClassNameMatches(entity, const String:className[], partialMatch=false)
+stock bool Entity_ClassNameMatches(int entity, const char[] className, bool partialMatch=false)
 {
-	decl String:entity_className[64];
+	char entity_className[64];
 	Entity_GetClassName(entity, entity_className, sizeof(entity_className));
 
 	if (partialMatch) {
@@ -152,9 +151,9 @@ stock bool:Entity_ClassNameMatches(entity, const String:className[], partialMatc
  * @param class			Name String.
  * @return				True if the name matches, false otherwise.
  */
-stock bool:Entity_NameMatches(entity, const String:name[])
+stock bool Entity_NameMatches(int intentity, const char[] name)
 {
-	decl String:entity_name[128];
+	char entity_name[128];
 	Entity_GetName(entity, entity_name, sizeof(entity_name));
 
 	return StrEqual(name, entity_name);
@@ -168,7 +167,7 @@ stock bool:Entity_NameMatches(entity, const String:name[])
  * @param size				Max size of buffer.
  * @return					Number of non-null bytes written.
  */
-stock Entity_GetName(entity, String:buffer[], size)
+stock int Entity_GetName(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_iName", buffer, size);
 }
@@ -180,9 +179,9 @@ stock Entity_GetName(entity, String:buffer[], size)
  * @param name				The name you want to give.
  * @return					True on success, false otherwise.
  */
-stock Entity_SetName(entity, const String:name[], any:...)
+stock bool Entity_SetName(int entity, const char[] name, any ...)
 {
-	decl String:format[128];
+	char format[128];
 	VFormat(format, sizeof(format), name, 3);
 
 	return DispatchKeyValue(entity, "targetname", format);
@@ -198,7 +197,7 @@ stock Entity_SetName(entity, const String:name[], any:...)
  * @param size				Max size of buffer.
  * @return					Number of non-null bytes written.
  */
-stock Entity_GetClassName(entity, String:buffer[], size)
+stock int Entity_GetClassName(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_iClassname", buffer, size);
 }
@@ -210,7 +209,7 @@ stock Entity_GetClassName(entity, String:buffer[], size)
  * @param name				The name you want to give.
  * @return					True on success, false otherwise.
  */
-stock Entity_SetClassName(entity, const String:className[])
+stock bool Entity_SetClassName(int entity, const char[] className)
 {
 	return DispatchKeyValue(entity, "classname", className);
 }
@@ -223,7 +222,7 @@ stock Entity_SetClassName(entity, const String:className[])
  * @param size				Max size of buffer.
  * @return					Number of non-null bytes written.
  */
-stock Entity_GetTargetName(entity, String:buffer[], size)
+stock int Entity_GetTargetName(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_target", buffer, size);
 }
@@ -235,9 +234,9 @@ stock Entity_GetTargetName(entity, String:buffer[], size)
  * @param name				The target name you want to set
  * @return					True on success, false otherwise.
  */
-stock Entity_SetTargetName(entity, const String:name[], any:...)
+stock bool Entity_SetTargetName(int entity, const char[] name, any ...)
 {
-	decl String:format[128];
+	char format[128];
 	VFormat(format, sizeof(format), name, 3);
 
 	return DispatchKeyValue(entity, "target", format);
@@ -251,7 +250,7 @@ stock Entity_SetTargetName(entity, const String:name[], any:...)
  * @param size				Max size of buffer.
  * @return					Number of non-null bytes written.
  */
-stock Entity_GetGlobalName(entity, String:buffer[], size)
+stock int Entity_GetGlobalName(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_iGlobalname", buffer, size);
 }
@@ -263,9 +262,9 @@ stock Entity_GetGlobalName(entity, String:buffer[], size)
  * @param name				The global name you want to set.
  * @return					True on success, false otherwise.
  */
-stock Entity_SetGlobalName(entity, const String:name[], any:...)
+stock bool Entity_SetGlobalName(int entity, const char[] name, any ...)
 {
-	decl String:format[128];
+	char format[128];
 	VFormat(format, sizeof(format), name, 3);
 
 	return DispatchKeyValue(entity, "globalname", format);
@@ -279,7 +278,7 @@ stock Entity_SetGlobalName(entity, const String:name[], any:...)
  * @param size				Max size of buffer.
  * @return					Number of non-null bytes written.
  */
-stock Entity_GetParentName(entity, String:buffer[], size)
+stock int Entity_GetParentName(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_iParent", buffer, size);
 }
@@ -291,9 +290,9 @@ stock Entity_GetParentName(entity, String:buffer[], size)
  * @param name				The parent name you want to set.
  * @return					True on success, false otherwise.
  */
-stock Entity_SetParentName(entity, const String:name[], any:...)
+stock bool Entity_SetParentName(int entity, const char[] name, any ...)
 {
-	decl String:format[128];
+	char format[128];
 	VFormat(format, sizeof(format), name, 3);
 
 	return DispatchKeyValue(entity, "parentname", format);
@@ -307,7 +306,7 @@ stock Entity_SetParentName(entity, const String:name[], any:...)
  * @param entity			Entity index.
  * @return					Hammer ID.
  */
-stock Entity_GetHammerId(entity)
+stock int Entity_GetHammerId(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_iHammerID");
 }
@@ -318,7 +317,7 @@ stock Entity_GetHammerId(entity)
  * @param entity			Entity index.
  * @return					Radius
  */
-stock Float:Entity_GetRadius(entity)
+stock float Entity_GetRadius(int entity)
 {
 	return GetEntPropFloat(entity, Prop_Data, "m_flRadius");
 }
@@ -330,7 +329,7 @@ stock Float:Entity_GetRadius(entity)
  * @param radius			Radius value
  * @noreturn
  */
-stock Entity_SetRadius(entity, Float:radius)
+stock void Entity_SetRadius(int entity, float radius)
 {
 	SetEntPropFloat(entity, Prop_Data, "m_flRadius", radius);
 }
@@ -340,9 +339,9 @@ stock Entity_SetRadius(entity, Float:radius)
  *
  * @param entity			Entity index.
  * @param vec				Vector.
- * @noreturn
+ * @noreturn 
  */
-stock Entity_GetMinSize(entity, Float:vec[3])
+stock void Entity_GetMinSize(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Send, "m_vecMins", vec);
 }
@@ -352,9 +351,9 @@ stock Entity_GetMinSize(entity, Float:vec[3])
  *
  * @param entity			Entity index.
  * @param vec				Vector.
- * @noreturn
+ * @noreturn 
  */
-stock Entity_SetMinSize(entity, const Float:vecMins[3])
+stock void Entity_SetMinSize(int entity, float vecMins[3])
 {
 	SetEntPropVector(entity, Prop_Send, "m_vecMins", vecMins);
 }
@@ -367,7 +366,7 @@ stock Entity_SetMinSize(entity, const Float:vecMins[3])
  * @param vec				return vector.
  * @noreturn
  */
-stock Entity_GetMaxSize(entity, Float:vec[3])
+stock void Entity_GetMaxSize(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Send, "m_vecMaxs", vec);
 }
@@ -380,7 +379,7 @@ stock Entity_GetMaxSize(entity, Float:vec[3])
  * @param vec				Vector.
  * @noreturn
  */
-stock Entity_SetMaxSize(entity, const Float:vecMaxs[3])
+stock void Entity_SetMaxSize(int entity, float vecMaxs[3])
 {
 	SetEntPropVector(entity, Prop_Send, "m_vecMaxs", vecMaxs);
 }
@@ -394,18 +393,18 @@ stock Entity_SetMaxSize(entity, const Float:vecMaxs[3])
  * @param vecMaxs			Max size Vector
  * @noreturn
  */
-stock Entity_SetMinMaxSize(entity, Float:vecMins[3], Float:vecMaxs[3])
+stock void Entity_SetMinMaxSize(int entity, float vecMins[3], float vecMaxs[3])
 {
 	// Taken from hl2sdk-ob-valve\game\server\util.cpp SetMinMaxSize()
 	// Todo: Replace this by a SDK call
-	for (new i=0; i<3; i++) {
+	for (int i=0; i<3; i++) {
 
 		if (vecMins[i] > vecMaxs[i]) {
 			ThrowError("Error: mins[%d] > maxs[%d] of entity %d", i, i, EntRefToEntIndex(entity));
 		}
 	}
 
-	decl Float:m_vecMins[3], Float:m_vecMaxs[3];
+	float m_vecMins[3], m_vecMaxs[3];
 	Entity_GetMinSize(entity, m_vecMins);
 	Entity_GetMaxSize(entity, m_vecMaxs);
 
@@ -416,7 +415,7 @@ stock Entity_SetMinMaxSize(entity, Float:vecMins[3], Float:vecMaxs[3])
 	Entity_SetMinSize(entity, vecMins);
 	Entity_SetMaxSize(entity, vecMaxs);
 
-	decl Float:vecSize[3];
+	float vecSize[3];
 	SubtractVectors(vecMaxs, vecMins, vecSize);
 	Entity_SetRadius(entity, GetVectorLength(vecSize) * 0.5);
 
@@ -492,7 +491,7 @@ stock Entity_SetMinMaxSize(entity, Float:vecMins[3], Float:vecMaxs[3])
  * @param entity			Entity index.
  * @return					Spawnflags value
  */
-stock Entity_GetSpawnFlags(entity)
+stock int Entity_GetSpawnFlags(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_spawnflags");
 }
@@ -504,7 +503,7 @@ stock Entity_GetSpawnFlags(entity)
  * @param flags				Flags value
  * @noreturn
  */
-stock Entity_SetSpawnFlags(entity, flags)
+stock void Entity_SetSpawnFlags(int entity, int flags)
 {
 	SetEntProp(entity, Prop_Data, "m_spawnflags", flags);
 }
@@ -516,9 +515,9 @@ stock Entity_SetSpawnFlags(entity, flags)
  * @param flags				Flags value
  * @noreturn
  */
-stock Entity_AddSpawnFlags(entity, flags)
+stock void Entity_AddSpawnFlags(int entity, int flags)
 {
-	new spawnFlags = Entity_GetSpawnFlags(entity);
+	int spawnFlags = Entity_GetSpawnFlags(entity);
 	spawnFlags |= flags;
 	Entity_SetSpawnFlags(entity, spawnFlags);
 }
@@ -530,9 +529,9 @@ stock Entity_AddSpawnFlags(entity, flags)
  * @param flags				Flags value
  * @noreturn
  */
-stock Entity_RemoveSpawnFlags(entity, flags)
+stock void Entity_RemoveSpawnFlags(int entity, int flags)
 {
-	new spawnFlags = Entity_GetSpawnFlags(entity);
+	int spawnFlags = Entity_GetSpawnFlags(int entity);
 	spawnFlags &= ~flags;
 	Entity_SetSpawnFlags(entity, spawnFlags);
 }
@@ -543,7 +542,7 @@ stock Entity_RemoveSpawnFlags(entity, flags)
  * @param entity			Entity index.
  * @noreturn
  */
-stock Entity_ClearSpawnFlags(entity)
+stock void Entity_ClearSpawnFlags(int entity)
 {
 	Entity_SetSpawnFlags(entity, 0);
 }
@@ -555,9 +554,9 @@ stock Entity_ClearSpawnFlags(entity)
  * @param flags				Flags value.
  * @return					True if the entity has the spawnflags set, false otherwise.
  */
-stock bool:Entity_HasSpawnFlags(entity, flags)
+stock bool Entity_HasSpawnFlags(int entity, int flags)
 {
-	return bool:(Entity_GetSpawnFlags(entity) & flags);
+	return view_as<bool>(Entity_GetSpawnFlags(entity) & flags);
 }
 
 /*
@@ -622,9 +621,9 @@ enum Entity_Flags
  * @param entity			Entity index.
  * @return					Entity flags value
  */
-stock Entity_Flags:Entity_GetEFlags(entity)
+stock Entity_Flags Entity_GetEFlags(int entity)
 {
-	return Entity_Flags:GetEntProp(entity, Prop_Data, "m_iEFlags");
+	return view_as<Entity_Flags>(GetEntProp(entity, Prop_Data, "m_iEFlags"));
 }
 
 /**
@@ -634,7 +633,7 @@ stock Entity_Flags:Entity_GetEFlags(entity)
  * @param flags				Flags value
  * @noreturn
  */
-stock Entity_SetEFlags(entity, Entity_Flags:flags)
+stock void Entity_SetEFlags(int entity, Entity_Flags flags)
 {
 	SetEntProp(entity, Prop_Data, "m_iEFlags", flags);
 }
@@ -646,9 +645,9 @@ stock Entity_SetEFlags(entity, Entity_Flags:flags)
  * @param flags				Flags value
  * @noreturn
  */
-stock Entity_AddEFlags(entity, Entity_Flags:flags)
+stock void Entity_AddEFlags(int entity, Entity_Flags flags)
 {
-	new Entity_Flags:setFlags = Entity_GetEFlags(entity);
+	Entity_Flags setFlags = Entity_GetEFlags(entity);
 	setFlags |= flags;
 	Entity_SetEFlags(entity, setFlags);
 }
@@ -660,9 +659,9 @@ stock Entity_AddEFlags(entity, Entity_Flags:flags)
  * @param flags				Flags value
  * @noreturn
  */
-stock Entity_RemoveEFlags(entity, Entity_Flags:flags)
+stock void Entity_RemoveEFlags(int entity, Entity_Flags flags)
 {
-	new Entity_Flags:setFlags = Entity_GetEFlags(entity);
+	Entity_Flags setFlags = Entity_GetEFlags(entity);
 	setFlags &= ~flags;
 	Entity_SetEFlags(entity, setFlags);
 }
@@ -674,11 +673,11 @@ stock Entity_RemoveEFlags(entity, Entity_Flags:flags)
  * @param flags				Flags value
  * @return					True if the flags are set, false otherwise.
  */
-stock bool:Entity_HasEFlags(entity, Entity_Flags:flags)
+stock bool Entity_HasEFlags(int entity, Entity_Flags flags)
 {
-	new Entity_Flags:currentEFlags = Entity_GetEFlags(entity);
+	Entity_Flags currentEFlags = Entity_GetEFlags(entity);
 
-	return bool:(currentEFlags & flags);
+	return view_as<bool>(currentEFlags & flags);
 }
 
 /**
@@ -688,7 +687,7 @@ stock bool:Entity_HasEFlags(entity, Entity_Flags:flags)
  * @param entity			Entity index.
  * @noreturn
  */
-stock Entity_MarkSurrBoundsDirty(entity)
+stock void Entity_MarkSurrBoundsDirty(int entity)
 {
 	Entity_AddEFlags(entity, EFL_DIRTY_SURR_COLLISION_BOUNDS);
 }
@@ -707,7 +706,7 @@ stock Entity_MarkSurrBoundsDirty(entity)
  * @param entity			Entity Index.
  * @return					Entity Flags.
  */
-stock Entity_GetFlags(entity)
+stock int Entity_GetFlags(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_fFlags");
 }
@@ -719,9 +718,9 @@ stock Entity_GetFlags(entity)
  * @param flags				New Flags value
  * @noreturn
  */
-stock Entity_SetFlags(entity, flags)
+stock void Entity_SetFlags(int entity, int flags)
 {
-	SetEntProp(entity, Prop_Data, "m_fFlags", flags);
+	SetEntProp(int entity, Prop_Data, "m_fFlags", flags);
 }
 
 /**
@@ -731,9 +730,9 @@ stock Entity_SetFlags(entity, flags)
  * @param flags				Flags to add
  * @noreturn
  */
-stock Entity_AddFlags(entity, flags)
+stock void Entity_AddFlags(int entity, int flags)
 {
-	new setFlags = Entity_GetFlags(entity);
+	int setFlags = Entity_GetFlags(entity);
 	setFlags |= flags;
 	Entity_SetFlags(entity, flags);
 }
@@ -745,9 +744,9 @@ stock Entity_AddFlags(entity, flags)
  * @param flags				Flags to remove
  * @noreturn
  */
-stock Entity_RemoveFlags(entity, flags)
+stock void Entity_RemoveFlags(int entity, int flags)
 {
-	new setFlags = Entity_GetFlags(entity);
+	int setFlags = Entity_GetFlags(entity);
 	setFlags &= ~flags;
 	Entity_SetFlags(entity, setFlags);
 }
@@ -761,9 +760,9 @@ stock Entity_RemoveFlags(entity, flags)
  * @param flags				Flag to Toggle
  * @noreturn
  */
-stock Entity_ToggleFlag(entity, flag)
+stock void Entity_ToggleFlag(int entity, int flag)
 {
-	new setFlag = Entity_GetFlags(entity);
+	int setFlag = Entity_GetFlags(entity);
 	setFlag ^= flag;
 	Entity_SetFlags(entity, setFlag);
 }
@@ -774,7 +773,7 @@ stock Entity_ToggleFlag(entity, flag)
  * @param entity			Entity index.
  * @noreturn
  */
-stock Entity_ClearFlags(entity)
+stock void Entity_ClearFlags(int entity)
 {
 	Entity_SetFlags(entity, 0);
 }
@@ -811,9 +810,9 @@ enum SolidFlags_t
  * @param entity			Entity index.
  * @return					Solid Flags.
  */
-stock SolidFlags_t:Entity_GetSolidFlags(entity)
+stock SolidFlags_t Entity_GetSolidFlags(int entity)
 {
-	return SolidFlags_t:GetEntProp(entity, Prop_Data, "m_usSolidFlags", 2);
+	return view_as<SolidFlags_t>(GetEntProp(entity, Prop_Data, "m_usSolidFlags", 2));
 }
 
 /**
@@ -823,10 +822,10 @@ stock SolidFlags_t:Entity_GetSolidFlags(entity)
  * @param flags				Solid Flags.
  * @noreturn
  */
-stock Entity_SetSolidFlags(entity, SolidFlags_t:flags)
+stock void Entity_SetSolidFlags(int entity, SolidFlags_t flags)
 {
-	new SolidFlags_t:oldFlags = Entity_GetSolidFlags(entity);
-	flags = flags & SolidFlags_t:0xFFFF;
+	SolidFlags_t oldFlags = Entity_GetSolidFlags(entity);
+	flags = flags & view_as<SolidFlags_t>(0xFFFF);
 
 	if (oldFlags == flags) {
 		return;
@@ -849,9 +848,9 @@ stock Entity_SetSolidFlags(entity, SolidFlags_t:flags)
  * @param flags				Solid Flags.
  * @noreturn
  */
-stock Entity_AddSolidFlags(entity, SolidFlags_t:flags)
+stock void Entity_AddSolidFlags(int entity, SolidFlags_t flags)
 {
-	new SolidFlags_t:newFlags = Entity_GetSolidFlags(entity);
+	SolidFlags_t newFlags = Entity_GetSolidFlags(entity);
 	newFlags |= flags;
 	Entity_SetSolidFlags(entity, newFlags);
 }
@@ -863,9 +862,9 @@ stock Entity_AddSolidFlags(entity, SolidFlags_t:flags)
  * @param flags				Solid Flags.
  * @noreturn
  */
-stock Entity_RemoveSolidFlags(entity, SolidFlags_t:flags)
+stock void Entity_RemoveSolidFlags(int entity, SolidFlags_t flags)
 {
-	new SolidFlags_t:newFlags = Entity_GetSolidFlags(entity);
+	SolidFlags_t newFlags = Entity_GetSolidFlags(entity);
 	newFlags &= ~flags;
 	Entity_SetSolidFlags(entity, newFlags);
 }
@@ -876,9 +875,9 @@ stock Entity_RemoveSolidFlags(entity, SolidFlags_t:flags)
  * @param entity			Entity index.
  * @noreturn
  */
-stock Entity_ClearSolidFlags(entity)
+stock void Entity_ClearSolidFlags(int entity)
 {
-	Entity_SetSolidFlags(entity, SolidFlags_t:0);
+	Entity_SetSolidFlags(entity, view_as<SolidFlags_t>(0));
 }
 
 /**
@@ -888,9 +887,9 @@ stock Entity_ClearSolidFlags(entity)
  * @param flags				Solid Flags.
  * @return					True if the specified flags are set, false otherwise.
  */
-stock bool:Entity_SolidFlagsSet(entity, SolidFlags_t:flagMask)
+stock bool Entity_SolidFlagsSet(int entity, SolidFlags_t flagMask)
 {
-	return bool:(Entity_GetSolidFlags(entity) & flagMask);
+	return view_as<bool>(Entity_GetSolidFlags(entity) & flagMask);
 }
 
 enum SolidType_t
@@ -911,9 +910,9 @@ enum SolidType_t
  * @param entity			Entity index.
  * @return					Solid Type
  */
-stock SolidType_t:Entity_GetSolidType(entity)
+stock SolidType_t Entity_GetSolidType(int entity)
 {
-	return SolidType_t:GetEntProp(entity, Prop_Data, "m_nSolidType", 1);
+	return view_as<SolidType_t>(GetEntProp(entity, Prop_Data, "m_nSolidType", 1));
 }
 
 /**
@@ -923,7 +922,7 @@ stock SolidType_t:Entity_GetSolidType(entity)
  * @param					Solid Type value.
  * @noreturn
  */
-stock Entity_SetSolidType(entity, SolidType_t:value)
+stock void Entity_SetSolidType(int entity, SolidType_t value)
 {
 	SetEntProp(entity, Prop_Send, "m_nSolidType", value, 1);
 	Entity_MarkSurrBoundsDirty(entity);
@@ -935,7 +934,7 @@ stock Entity_SetSolidType(entity, SolidType_t:value)
  * @param entity			Entity index.
  * @return					True if the entity is solid, false otherwise.
  */
-stock bool:Entity_IsSolid(entity)
+stock bool Entity_IsSolid(int entity)
 {
 	return (Entity_GetSolidType(entity) != SOLID_NONE &&
 			!Entity_SolidFlagsSet(entity, FSOLID_NOT_SOLID));
@@ -950,7 +949,7 @@ stock bool:Entity_IsSolid(entity)
  * @param size			max size of buffer string
  * @return				Number of non-null bytes written.
  */
-stock Entity_GetModel(entity, String:buffer[], size)
+stock void Entity_GetModel(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_ModelName", buffer, size);
 }
@@ -964,7 +963,7 @@ stock Entity_GetModel(entity, String:buffer[], size)
  * @param model			Model name
  * @noreturn
  */
-stock Entity_SetModel(entity, const String:model[])
+stock void Entity_SetModel(int entity, const char[] model)
 {
 	SetEntityModel(entity, model);
 }
@@ -975,7 +974,7 @@ stock Entity_SetModel(entity, const String:model[])
  * @param entity			Entity index.
  * @return					The Entity's model index
  */
-stock Entity_GetModelIndex(entity)
+stock int Entity_GetModelIndex(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_nModelIndex", 2);
 }
@@ -987,7 +986,7 @@ stock Entity_GetModelIndex(entity)
  * @param index				Model Index.
  * @noreturn
  */
-stock Entity_SetModelIndex(entity, index)
+stock void Entity_SetModelIndex(int entity, int index)
 {
 	SetEntProp(entity, Prop_Data, "m_nModelIndex", index, 2);
 }
@@ -999,7 +998,7 @@ stock Entity_SetModelIndex(entity, index)
 * @param maxspeed	the maximum speed the entity can move
 * @noreturn
 */
-stock Entity_SetMaxSpeed(entity, Float:value)
+stock void Entity_SetMaxSpeed(int entity, float value)
 {
 	SetEntPropFloat(entity, Prop_Data, "m_flMaxspeed", value);
 }
@@ -1040,9 +1039,9 @@ enum Collision_Group_t
  * @param entity		entity index
  * @return				Entity collision group.
  */
-stock Collision_Group_t:Entity_GetCollisionGroup(entity)
+stock Collision_Group_t Entity_GetCollisionGroup(int entity)
 {
-	return Collision_Group_t:GetEntProp(entity, Prop_Data, "m_CollisionGroup");
+	return view_as<Collision_Group_t>(GetEntProp(entity, Prop_Data, "m_CollisionGroup"));
 }
 
 /**
@@ -1052,7 +1051,7 @@ stock Collision_Group_t:Entity_GetCollisionGroup(entity)
  * @param value			the new collision group.
  * @noreturn
  */
-stock Entity_SetCollisionGroup(entity, Collision_Group_t:value)
+stock void Entity_SetCollisionGroup(int entity, Collision_Group_t value)
 {
 	SetEntProp(entity, Prop_Data, "m_CollisionGroup", value);
 }
@@ -1070,7 +1069,7 @@ stock Entity_SetCollisionGroup(entity, Collision_Group_t:value)
  * @param vec				3 dimensional vector array.
  * @noreturn
  */
-stock Entity_GetAbsOrigin(entity, Float:vec[3])
+stock void Entity_GetAbsOrigin(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Send, "m_vecOrigin", vec);
 }
@@ -1082,7 +1081,7 @@ stock Entity_GetAbsOrigin(entity, Float:vec[3])
  * @param vec				3 dimensional vector array.
  * @noreturn
  */
-stock Entity_SetAbsOrigin(entity, const Float:vec[3])
+stock void Entity_SetAbsOrigin(int entity, float vec[3])
 {
 	// We use TeleportEntity to set the origin more safely
 	// Todo: Replace this with a call to UTIL_SetOrigin() or CBaseEntity::SetLocalOrigin()
@@ -1102,7 +1101,7 @@ stock Entity_SetAbsOrigin(entity, const Float:vec[3])
  * @param vec				3 dimensional vector array.
  * @noreturn
  */
-stock Entity_GetAbsAngles(entity, Float:vec[3])
+stock void Entity_GetAbsAngles(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Data, "m_angAbsRotation", vec);
 }
@@ -1114,7 +1113,7 @@ stock Entity_GetAbsAngles(entity, Float:vec[3])
  * @param vec				3 dimensional vector array.
  * @noreturn
  */
-stock Entity_SetAbsAngles(entity, const Float:vec[3])
+stock void Entity_SetAbsAngles(int entity, float vec[3])
 {
 	// We use TeleportEntity to set the angles more safely
 	// Todo: Replace this with a call to CBaseEntity::SetLocalAngles()
@@ -1135,7 +1134,7 @@ stock Entity_SetAbsAngles(entity, const Float:vec[3])
  * @param vel			An 3 dim array
  * @noreturn
  */
-stock Entity_GetLocalVelocity(entity, Float:vec[3])
+stock void Entity_GetLocalVelocity(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Data, "m_vecVelocity", vec);
 }
@@ -1150,7 +1149,7 @@ stock Entity_GetLocalVelocity(entity, Float:vec[3])
  * @param vel			An 3 dim array
  * @noreturn
  */
-stock Entity_SetLocalVelocity(entity, const Float:vec[3])
+stock void Entity_SetLocalVelocity(int entity, const float vec[3])
 {
 	SetEntPropVector(entity, Prop_Data, "m_vecVelocity", vec);
 }
@@ -1164,7 +1163,7 @@ stock Entity_SetLocalVelocity(entity, const Float:vec[3])
  * @param vel			An 3 dim array
  * @noreturn
  */
-stock Entity_GetBaseVelocity(entity, Float:vec[3])
+stock void Entity_GetBaseVelocity(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Data, "m_vecBaseVelocity", vec);
 }
@@ -1178,7 +1177,7 @@ stock Entity_GetBaseVelocity(entity, Float:vec[3])
  * @param vel			An 3 dim array
  * @noreturn
  */
-stock Entity_SetBaseVelocity(entity, const Float:vec[3])
+stock void Entity_SetBaseVelocity(int entity, const float vec[3])
 {
 	SetEntPropVector(entity, Prop_Data, "m_vecBaseVelocity", vec);
 }
@@ -1192,7 +1191,7 @@ stock Entity_SetBaseVelocity(entity, const Float:vec[3])
  * @param vel			An 3 dim array
  * @noreturn
  */
-stock Entity_GetAbsVelocity(entity, Float:vec[3])
+stock void Entity_GetAbsVelocity(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Data, "m_vecAbsVelocity", vec);
 }
@@ -1206,7 +1205,7 @@ stock Entity_GetAbsVelocity(entity, Float:vec[3])
  * @param vel			An 3 dim array
  * @noreturn
  */
-stock Entity_SetAbsVelocity(entity, const Float:vec[3])
+stock void Entity_SetAbsVelocity(int entity, const float vec[3])
 {
 	// We use TeleportEntity to set the velocity more safely
 	// Todo: Replace this with a call to CBaseEntity::SetAbsVelocity()
@@ -1219,9 +1218,9 @@ stock Entity_SetAbsVelocity(entity, const Float:vec[3])
  * @param entity		Entity index.
  * @return				True if locked otherwise false.
  */
-stock bool:Entity_IsLocked(entity)
+stock bool Entity_IsLocked(int entity)
 {
-	return bool:GetEntProp(entity, Prop_Data, "m_bLocked", 1);
+	return view_as<bool>(GetEntProp(entity, Prop_Data, "m_bLocked", 1));
 }
 
 /**
@@ -1230,7 +1229,7 @@ stock bool:Entity_IsLocked(entity)
  * @param entity		Entity index.
  * @noreturn
  */
-stock Entity_Lock(entity)
+stock void Entity_Lock(int entity)
 {
 	SetEntProp(entity, Prop_Data, "m_bLocked", 1, 1);
 }
@@ -1240,7 +1239,7 @@ stock Entity_Lock(entity)
  * @param entity		Entity index.
  * @noreturn
  */
-stock Entity_UnLock(entity)
+stock void Entity_UnLock(int entity)
 {
 	SetEntProp(entity, Prop_Data, "m_bLocked", 0, 1);
 }
@@ -1251,7 +1250,7 @@ stock Entity_UnLock(entity)
  * @param entity			entity index.
  * @return				current health points
  */
-stock Entity_GetHealth(entity)
+stock int Entity_GetHealth(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_iHealth");
 }
@@ -1261,14 +1260,14 @@ stock Entity_GetHealth(entity)
  *
  * @param entity			entity index.
  * @param value			health to set (anything above 511 will overload)
- * @noreturn
+ * @return 				Amount of health set
  */
-stock Entity_SetHealth(entity, value, ignoreMax=false, kill=true)
+stock int Entity_SetHealth(int entity, int value, bool ignoreMax=false, bool kill=true)
 {
-	new health = value;
+	int health = value;
 
 	if (!ignoreMax) {
-		new maxHealth = Entity_GetMaxHealth(entity);
+		int maxHealth = Entity_GetMaxHealth(entity);
 
 		if (health > maxHealth) {
 			health = maxHealth;
@@ -1295,9 +1294,9 @@ stock Entity_SetHealth(entity, value, ignoreMax=false, kill=true)
  * @param value			health to add
  * @return				returns the new health value set
  */
-stock Entity_AddHealth(entity, value, ignoreMax=false, kill=true)
+stock int Entity_AddHealth(int entity, int value, bool ignoreMax=false, bool kill=true)
 {
-	new health = Entity_GetHealth(entity);
+	int health = Entity_GetHealth(entity);
 
 	health += value;
 
@@ -1311,9 +1310,9 @@ stock Entity_AddHealth(entity, value, ignoreMax=false, kill=true)
  * @param value			health to add
  * @return				returns the new health value set
  */
-stock Entity_TakeHealth(entity, value, ignoreMax=false, kill=true)
+stock int Entity_TakeHealth(int entity, int value, bool ignoreMax=false, bool kill=true)
 {
-	new health = Entity_GetHealth(entity);
+	int health = Entity_GetHealth(entity);
 
 	health -= value;
 
@@ -1326,7 +1325,7 @@ stock Entity_TakeHealth(entity, value, ignoreMax=false, kill=true)
  * @param entity		Entity Index
  * @return				Max health points
  */
-stock Entity_GetMaxHealth(entity)
+stock int Entity_GetMaxHealth(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_iMaxHealth");
 }
@@ -1339,7 +1338,7 @@ stock Entity_GetMaxHealth(entity)
  * @param value			Max health to set (anything above 511 will overload)
  * @noreturn
  */
-stock Entity_SetMaxHealth(entity, value)
+stock void Entity_SetMaxHealth(int entity, int value)
 {
 	SetEntProp(entity, Prop_Data, "m_iMaxHealth", value);
 	return value;
@@ -1353,9 +1352,9 @@ stock Entity_SetMaxHealth(entity, value)
  * @param target		Vector Origin.
  * @return				Distance Float value.
  */
-stock Float:Entity_GetDistanceOrigin(entity, const Float:vec[3])
+stock float Entity_GetDistanceOrigin(int entity, const float vec[3])
 {
-	new Float:entityVec[3];
+	float entityVec[3];
 	Entity_GetAbsOrigin(entity, entityVec);
 
 	return GetVectorDistance(entityVec, vec);
@@ -1369,9 +1368,9 @@ stock Float:Entity_GetDistanceOrigin(entity, const Float:vec[3])
  * @param target		Target Entity Index.
  * @return				Distance Float value.
  */
-stock Float:Entity_GetDistance(entity, target)
+stock float Entity_GetDistance(int entity, int target)
 {
-	new Float:targetVec[3];
+	float targetVec[3];
 	Entity_GetAbsOrigin(target, targetVec);
 
 	return Entity_GetDistanceOrigin(entity, targetVec);
@@ -1385,7 +1384,7 @@ stock Float:Entity_GetDistance(entity, target)
  * @param distance		Max Float distance.
  * @return				True if the given entities are closer than the given distance value, false otherwise.
  */
-stock bool:Entity_InRange(entity, target, Float:distance)
+stock bool Entity_InRange(int entity, int target, float distance)
 {
 	if (Entity_GetDistance(entity, target) > distance) {
 		return false;
@@ -1400,7 +1399,7 @@ stock bool:Entity_InRange(entity, target, Float:distance)
  * @param entity		Entity index.
  * @return				True on success, false otherwise
  */
-stock bool:Entity_EnableMotion(entity)
+stock bool Entity_EnableMotion(int entity)
 {
 	return AcceptEntityInput(entity, "enablemotion");
 }
@@ -1411,7 +1410,7 @@ stock bool:Entity_EnableMotion(entity)
  * @param entity		Entity index.
  * @return 				True on success, false otherwise
  */
-stock bool:Entity_DisableMotion(entity)
+stock bool Entity_DisableMotion(int entity)
 {
 	return AcceptEntityInput(entity, "disablemotion");
 }
@@ -1420,9 +1419,9 @@ stock bool:Entity_DisableMotion(entity)
  * Freezes an entity by setting the FL_FROZEN flag.
  *
  * @param entity		Entity index.
- * @return				True on success, false otherwise
+ * @noreturn
  */
-stock Entity_Freeze(entity)
+stock void Entity_Freeze(int entity)
 {
 	Entity_AddFlags(entity, FL_FROZEN);
 }
@@ -1431,9 +1430,9 @@ stock Entity_Freeze(entity)
  * Unfreezes an entity by removing the FL_FROZEN flag.
  *
  * @param entity		Entity index.
- * @return 				True on success, false otherwise
+ * @noreturn
  */
-stock Entity_UnFreeze(entity)
+stock void Entity_UnFreeze(int entity)
 {
 	Entity_RemoveFlags(entity, FL_FROZEN);
 }
@@ -1449,9 +1448,9 @@ stock Entity_UnFreeze(entity)
  * @param				Optional: target name
  * @noreturn
  */
-stock Entity_PointAtTarget(entity, target, const String:name[]="")
+stock void Entity_PointAtTarget(int entity, int target, const char name[]="")
 {
-	decl String:targetName[128];
+	char targetName[128];
 	Entity_GetTargetName(entity, targetName, sizeof(targetName));
 
 	if (name[0] == '\0') {
@@ -1484,9 +1483,9 @@ stock Entity_PointAtTarget(entity, target, const String:name[]="")
  * @param					Optional: target name
  * @noreturn
  */
-stock Entity_PointHurtAtTarget(entity, target, const String:name[]="")
+stock void Entity_PointHurtAtTarget(int entity, int target, const char[] name="")
 {
-	decl String:targetName[128];
+	char targetName[128];
 	Entity_GetTargetName(entity, targetName, sizeof(targetName));
 
 	if (name[0] == '\0') {
@@ -1517,7 +1516,7 @@ stock Entity_PointHurtAtTarget(entity, target, const String:name[]="")
  * @param entity			Entity index.
  * @return 				True if the entity is a player, false otherwise.
  */
-stock bool:Entity_IsPlayer(entity)
+stock bool Entity_IsPlayer(int entity)
 {
 	if (entity < 1 || entity > MaxClients) {
 		return false;
@@ -1533,7 +1532,7 @@ stock bool:Entity_IsPlayer(entity)
  * @param ForceEdictIndex	Edict Index to use.
  * @return 					Entity Index or INVALID_ENT_REFERENCE if the slot is already in use.
  */
-stock Entity_Create(const String:className[], ForceEdictIndex=-1)
+stock int Entity_Create(const char[] className, int ForceEdictIndex=-1)
 {
 	if (ForceEdictIndex != -1 && Entity_IsValid(ForceEdictIndex)) {
 		return INVALID_ENT_REFERENCE;
@@ -1551,7 +1550,7 @@ stock Entity_Create(const String:className[], ForceEdictIndex=-1)
  * @param killChildren	When true, kennys children are killed too.
  * @return 				True on success, false otherwise.
  */
-stock bool:Entity_Kill(kenny, killChildren=false)
+stock bool Entity_Kill(int kenny, bool killChildren=false)
 {
 	if (Entity_IsPlayer(kenny)) {
 		// Oh My God! They Killed Kenny!!
@@ -1575,11 +1574,11 @@ stock bool:Entity_Kill(kenny, killChildren=false)
  * @param className		Entity Network Class to search for.
  * @return 				Number of entities killed.
  */
-stock Entity_KillAllByClassName(const String:className[])
+stock int Entity_KillAllByClassName(const char[] className)
 {
-	new x = 0;
+	int x = 0;
 
-	new entity = INVALID_ENT_REFERENCE;
+	int entity = INVALID_ENT_REFERENCE;
 	while ((entity = FindEntityByClassname(entity, className)) != INVALID_ENT_REFERENCE) {
 		AcceptEntityInput(entity, "kill");
 		x++;
@@ -1595,7 +1594,7 @@ stock Entity_KillAllByClassName(const String:className[])
  * @param entity		Entity index.
  * @return 				Ground Entity or -1
  */
-stock Entity_GetOwner(entity)
+stock int Entity_GetOwner(int entity)
 {
 	return GetEntPropEnt(entity, Prop_Data, "m_hOwnerEntity");
 }
@@ -1607,7 +1606,7 @@ stock Entity_GetOwner(entity)
  * @param entity			Entity index.
  * @noreturn
  */
-stock Entity_SetOwner(entity, newOwner)
+stock void Entity_SetOwner(int entity, int newOwner)
 {
 	SetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity", newOwner);
 }
@@ -1618,7 +1617,7 @@ stock Entity_SetOwner(entity, newOwner)
  * @param entity		Entity index.
  * @return 				Ground Entity or -1
  */
-stock Entity_GetGroundEntity(entity)
+stock int Entity_GetGroundEntity(int entity)
 {
 	return GetEntPropEnt(entity, Prop_Data, "m_hGroundEntity");
 }
@@ -1690,9 +1689,9 @@ stock Entity_GetGroundEntity(entity)
  * 						want a specific weapon to be shown in the HUD kill message.
  * @return 				True on success, false otherwise.
  */
-stock bool:Entity_Hurt(entity, damage, attacker=0, damageType=DMG_GENERIC, const String:fakeClassName[]="")
+stock bool Entity_Hurt(int entity, int damage, int attacker=0, int damageType=DMG_GENERIC, const char fakeClassName[]="")
 {
-	static point_hurt = INVALID_ENT_REFERENCE;
+	static int point_hurt = INVALID_ENT_REFERENCE;
 
 	if (point_hurt == INVALID_ENT_REFERENCE || !IsValidEntity(point_hurt)) {
 		point_hurt = EntIndexToEntRef(Entity_Create("point_hurt"));
@@ -1729,7 +1728,7 @@ stock bool:Entity_Hurt(entity, damage, attacker=0, damageType=DMG_GENERIC, const
  * @param entity		Entity Index.
  * @return				Entity Index of the parent.
  */
-stock Entity_GetParent(entity)
+stock int Entity_GetParent(int entity)
 {
 	return GetEntPropEnt(entity, Prop_Data, "m_pParent");
 }
@@ -1740,7 +1739,7 @@ stock Entity_GetParent(entity)
  * @param entity		Entity Index.
  * @noreturn
  */
-stock Entity_ClearParent(entity)
+stock void Entity_RemoveParent(int entity)
 {
 	SetVariantString("");
 	AcceptEntityInput(entity, "ClearParent");
@@ -1753,10 +1752,10 @@ stock Entity_ClearParent(entity)
  * @param parentEntity	Entity Index of the new parent.
  * @noreturn
  */
-stock Entity_SetParent(entity, parent)
+stock void Entity_SetParent(int entity, int parentEntity)
 {
 	SetVariantString("!activator");
-	AcceptEntityInput(entity, "SetParent", parent);
+	AcceptEntityInput(entity, "SetParent", parentEntity);
 }
 
 
@@ -1770,7 +1769,7 @@ stock Entity_SetParent(entity, parent)
  * @param currentCall	The current call number (0 is the 1st call at 0.0 seconds, 1 the 2nd call at tick*1 seconds, ...).
  * @return				When true this callback will be called again at the next defined tick, otherwise it won't.
  */
-functag Entity_ChangeOverTimeCallback bool:public(&entity, &Float:interval, &currentCall);
+typedef Entity_ChangeOverTimeCallback = function bool (int &entity, float &interval, int &currentCall);
 
 /*
  * Creates a timer and provides a callback to change various things about an entity over time.
@@ -1779,38 +1778,31 @@ functag Entity_ChangeOverTimeCallback bool:public(&entity, &Float:interval, &cur
  * @param interval			Interval from the current game time to execute the given function.
  * @noreturn
  */
-stock Entity_ChangeOverTime(entity, Float:interval=0.1, Entity_ChangeOverTimeCallback:valueCallback)
+stock void Entity_ChangeOverTime(int entity, float interval=0.1, Entity_ChangeOverTimeCallback valueCallback)
 {
-	new Handle:dataPack = CreateDataPack();
-	WritePackCell(dataPack, EntIndexToEntRef(entity));
-	WritePackFloat(dataPack, interval);
-	WritePackCell(dataPack, 0);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	WritePackFunction(dataPack, valueCallback);
-#else
-	WritePackCell(dataPack, _:valueCallback);
-#endif
-	ResetPack(dataPack);
-	__smlib_Timer_ChangeOverTime(INVALID_HANDLE,dataPack);
+	DataPack dataPack = new DataPack();
+	dataPack.WriteCell(EntIndexToEntRef(entity));
+	dataPack.WriteFloat(interval);
+	dataPack.WriteCell(0);
+	dataPack.WriteFunction(valueCallback);
+	dataPack.Reset();
+	__smlib_Timer_ChangeOverTime(null,dataPack);
 }
 
-public Action:__smlib_Timer_ChangeOverTime(Handle:Timer, Handle:dataPack)
+public Action __smlib_Timer_ChangeOverTime(Handle Timer, DataPack dataPack)
 {
-	new entity = EntRefToEntIndex(ReadPackCell(dataPack));
+	int entity = EntRefToEntIndex(dataPack.ReadCell());
 	if(!Entity_IsValid(entity)){
 		return Plugin_Stop;
 	}
 
-	new Float:interval = ReadPackFloat(dataPack);
-	new currentCall = ReadPackCell(dataPack);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	new Function:callback = ReadPackFunction(dataPack);
-#else
-	new Function:callback = Function:ReadPackCell(dataPack);
-#endif
+	float interval = dataPack.ReadFloat();
+	int currentCall = dataPack.ReadCell();
 
-	new any:result;
-	Call_StartFunction(INVALID_HANDLE, callback);
+	Function callback = dataPack.ReadFunction();
+
+	any result;
+	Call_StartFunction(null, callback);
 	Call_PushCellRef(entity);
 	Call_PushFloatRef(interval);
 	Call_PushCellRef(currentCall);
@@ -1820,16 +1812,12 @@ public Action:__smlib_Timer_ChangeOverTime(Handle:Timer, Handle:dataPack)
 		return Plugin_Stop;
 	}
 
-	ResetPack(dataPack,true);
-	WritePackCell(dataPack, EntIndexToEntRef(entity));
-	WritePackFloat(dataPack, interval);
-	WritePackCell(dataPack, currentCall+1);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	WritePackFunction(dataPack, callback);
-#else
-	WritePackCell(dataPack, _:callback);
-#endif
-	ResetPack(dataPack);
+	dataPack.Reset(true);
+	dataPack.WriteCell(EntIndexToEntRef(entity));
+	dataPack.WriteFloat(interval);
+	dataPack.WriteCell(currentCall+1);
+	dataPack.WriteFunction(callback);
+	dataPack.Reset();
 	CreateTimer(interval,__smlib_Timer_ChangeOverTime,dataPack);
 	return Plugin_Stop;
 }
@@ -1842,9 +1830,9 @@ public Action:__smlib_Timer_ChangeOverTime(Handle:Timer, Handle:dataPack)
  * @param start			Start Index.
  * @return				Entity Index or -1 if no entity was found.
  */
-stock Entity_GetNextChild(parent, start=0)
+stock int Entity_GetNextChild(int parent, int start=0)
 {
-	for (new entity=start; entity <= 2048; entity++) {
+	for (int entity=start; entity <= 2048; entity++) {
 
 		if (!Entity_IsValid(entity)) {
 			continue;
@@ -1869,7 +1857,7 @@ stock Entity_GetNextChild(parent, start=0)
  * @param vec				Vector.
  * @noreturn
  */
-stock Entity_GetMoveDirection(entity, Float:vec[3])
+stock void Entity_GetMoveDirection(int entity, float vec[3])
 {
 	GetEntPropVector(entity, Prop_Data, "m_vecMoveDir", vec);
 }
@@ -1881,7 +1869,7 @@ stock Entity_GetMoveDirection(entity, Float:vec[3])
  * @param vec				Vector.
  * @noreturn
  */
-stock Entity_SetMoveDirection(entity, const Float:vec[3])
+stock void Entity_SetMoveDirection(int entity, const float vec[3])
 {
 	SetEntPropVector(entity, Prop_Data, "m_vecMoveDir", vec);
 }
@@ -1892,9 +1880,9 @@ stock Entity_SetMoveDirection(entity, const Float:vec[3])
  * @param entity			Entity index.
  * @return					True if the door will force close, otherwise false.
  */
-stock bool:Entity_GetForceClose(entity)
+stock bool Entity_GetForceClose(int entity)
 {
-	return bool:GetEntProp(entity, Prop_Data, "m_bForceClosed");
+	return view_as<bool>(GetEntProp(entity, Prop_Data, "m_bForceClosed"));
 }
 
 /**
@@ -1904,7 +1892,7 @@ stock bool:Entity_GetForceClose(entity)
  * @param forceClose		If true the door will force close, otherwise it won't.
  * @noreturn
  */
-stock Entity_SetForceClose(entity, bool:forceClose)
+stock void Entity_SetForceClose(int entity, bool forceClose)
 {
 	SetEntProp(entity, Prop_Data, "m_bForceClosed", forceClose);
 }
@@ -1915,7 +1903,7 @@ stock Entity_SetForceClose(entity, bool:forceClose)
  * @param entity			Entity index.
  * @return					Speed of the entity.
  */
-stock Float:Entity_GetSpeed(entity)
+stock float Entity_GetSpeed(int entity)
 {
 	return GetEntPropFloat(entity, Prop_Data, "m_flSpeed");
 }
@@ -1927,7 +1915,7 @@ stock Float:Entity_GetSpeed(entity)
  * @param speed				The new speed of the entity.
  * @noreturn
  */
-stock Entity_SetSpeed(entity, Float:speed)
+stock void Entity_SetSpeed(int entity, float speed)
 {
 	SetEntPropFloat(entity, Prop_Data, "m_flSpeed", speed);
 }
@@ -1939,7 +1927,7 @@ stock Entity_SetSpeed(entity, Float:speed)
  * @param entity			Entity index.
  * @return					Damage.
  */
-stock Float:Entity_GetBlockDamage(entity)
+stock float Entity_GetBlockDamage(int entity)
 {
 	return GetEntPropFloat(entity, Prop_Data, "m_flBlockDamage");
 }
@@ -1952,7 +1940,7 @@ stock Float:Entity_GetBlockDamage(entity)
  * @param damage			Damage.
  * @noreturn
  */
-stock Entity_SetBlockDamage(entity, Float:damage)
+stock void Entity_SetBlockDamage(int entity, float damage)
 {
 	SetEntPropFloat(entity, Prop_Data, "m_flBlockDamage", damage);
 }
@@ -1963,9 +1951,9 @@ stock Entity_SetBlockDamage(entity, Float:damage)
  * @param entity			Entity index.
  * @return					True if entity is disabled, otherwise false.
  */
-stock bool:Entity_IsDisabled(entity)
+stock bool Entity_IsDisabled(int entity)
 {
-	return bool:GetEntProp(entity, Prop_Data, "m_bDisabled", 1);
+	return view_as<bool>(GetEntProp(entity, Prop_Data, "m_bDisabled", 1));
 }
 
 /**
@@ -1974,7 +1962,7 @@ stock bool:Entity_IsDisabled(entity)
  * @param entity			Entity index.
  * @return					True if successful otherwise false.
  */
-stock Entity_Disable(entity)
+stock bool Entity_Disable(int entity)
 {
 	return AcceptEntityInput(entity, "Disable");
 }
@@ -1985,7 +1973,7 @@ stock Entity_Disable(entity)
  * @param entity			Entity index.
  * @return					True if successful otherwise false.
  */
-stock Entity_Enable(entity)
+stock bool Entity_Enable(int entity)
 {
 	return AcceptEntityInput(entity, "Enable");
 }
@@ -2005,7 +1993,7 @@ stock Entity_Enable(entity)
  * @param value				Mode, use DAMAGE_* defines.
  * @noreturn
  */
-stock Entity_SetTakeDamage(entity, value)
+stock void Entity_SetTakeDamage(int entity, int value)
 {
 	SetEntProp(entity, Prop_Data, "m_takedamage", value, 1);
 }
@@ -2017,7 +2005,7 @@ stock Entity_SetTakeDamage(entity, value)
  * @param entity			Entity index.
  * @return					Take damage mode (DAMAGE_*).
  */
-stock Entity_GetTakeDamage(entity)
+stock int Entity_GetTakeDamage(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_takedamage", 1);
 }
@@ -2030,7 +2018,7 @@ stock Entity_GetTakeDamage(entity)
  * @param minDamage			Minimum required damage.
  * @noreturn
  */
-stock Entity_SetMinHealthDamage(entity, minDamage)
+stock void Entity_SetMinHealthDamage(int entity, int minDamage)
 {
 	SetEntProp(entity, Prop_Data, "m_iMinHealthDmg", minDamage);
 }
@@ -2042,7 +2030,7 @@ stock Entity_SetMinHealthDamage(entity, minDamage)
  * @param entity			Entity index.
  * @return					Minimum required damage.
  */
-stock Entity_GetMinHealthDamage(entity)
+stock int Entity_GetMinHealthDamage(int entity)
 {
 	return GetEntProp(entity, Prop_Data, "m_iMinHealthDmg");
 }
@@ -2055,15 +2043,15 @@ stock Entity_GetMinHealthDamage(entity)
  * @noreturn
  * @error			Invalid entity index, or lack of mod compliance.
  */
-stock Entity_GetRenderColor(entity, color[4])
+stock void Entity_GetRenderColor(int entity, int color[4])
 {
-	static bool:gotconfig = false;
-	static String:prop[32];
+	static bool gotconfig = false;
+	static char prop[32];
 
 	if (!gotconfig) {
-		new Handle:gc = LoadGameConfigFile("core.games");
-		new bool:exists = GameConfGetKeyValue(gc, "m_clrRender", prop, sizeof(prop));
-		CloseHandle(gc);
+		Handle gc = LoadGameConfigFile("core.games");
+		bool exists = GameConfGetKeyValue(gc, "m_clrRender", prop, sizeof(prop));
+		delete gc;
 
 		if (!exists) {
 			strcopy(prop, sizeof(prop), "m_clrRender");
@@ -2072,13 +2060,13 @@ stock Entity_GetRenderColor(entity, color[4])
 		gotconfig = true;
 	}
 
-	new offset = GetEntSendPropOffs(entity, prop);
+	int offset = GetEntSendPropOffs(entity, prop);
 
 	if (offset <= 0) {
 		ThrowError("SetEntityRenderColor not supported by this mod");
 	}
 
-	for (new i=0; i < 4; i++) {
+	for (int i=0; i < 4; i++) {
 		color[i] = GetEntData(entity, offset + i + 1, 1);
 	}
 }
@@ -2095,15 +2083,15 @@ stock Entity_GetRenderColor(entity, color[4])
  * @noreturn
  * @error			Invalid entity index, or lack of mod compliance.
  */
-stock Entity_SetRenderColor(entity, r=-1, g=-1, b=-1, a=-1)
+stock void Entity_SetRenderColor(int entity, int r=-1, int g=-1, int b=-1, int a=-1)
 {
-	static bool:gotconfig = false;
-	static String:prop[32];
+	static bool gotconfig = false;
+	static char prop[32];
 
 	if (!gotconfig) {
-		new Handle:gc = LoadGameConfigFile("core.games");
-		new bool:exists = GameConfGetKeyValue(gc, "m_clrRender", prop, sizeof(prop));
-		CloseHandle(gc);
+		Handle gc = LoadGameConfigFile("core.games");
+		bool exists = GameConfGetKeyValue(gc, "m_clrRender", prop, sizeof(prop));
+		delete gc;
 
 		if (!exists) {
 			strcopy(prop, sizeof(prop), "m_clrRender");
@@ -2112,7 +2100,7 @@ stock Entity_SetRenderColor(entity, r=-1, g=-1, b=-1, a=-1)
 		gotconfig = true;
 	}
 
-	new offset = GetEntSendPropOffs(entity, prop);
+	int offset = GetEntSendPropOffs(entity, prop);
 
 	if (offset <= 0) {
 		ThrowError("SetEntityRenderColor not supported by this mod");
@@ -2145,7 +2133,7 @@ stock Entity_SetRenderColor(entity, r=-1, g=-1, b=-1, a=-1)
  * @param outputid		Unknown.
  * @return				True if successful, otherwise false.
  */
-stock bool:Entity_AddOutput(entity, const String:input[], activator=-1, caller=-1, outputid=0)
+stock bool Entity_AddOutput(int entity, const char[] input, int activator=-1, int caller=-1, int outputid=0)
 {
 	SetVariantString(input);
 	return AcceptEntityInput(entity, "addoutput", activator, caller, outputid);

--- a/scripting/include/smlib/entities.inc
+++ b/scripting/include/smlib/entities.inc
@@ -1739,9 +1739,8 @@ stock int Entity_GetParent(int entity)
  * Clears the parent of an entity.
  *
  * @param entity		Entity Index.
- * @noreturn
  */
-stock void Entity_RemoveParent(int entity)
+stock void Entity_ClearParent(int entity)
 {
 	SetVariantString("");
 	AcceptEntityInput(entity, "ClearParent");

--- a/scripting/include/smlib/entities.inc
+++ b/scripting/include/smlib/entities.inc
@@ -6,6 +6,8 @@
 #include <sourcemod>
 #include <sdktools_entinput>
 #include <sdktools_functions>
+// Sourcemod 1.9+ compatibility
+#tryinclude <sdktools_variant_t>
 
 /**
  * Macro for iterating trough all children (entities it is parent of) of an entity.
@@ -151,7 +153,7 @@ stock bool Entity_ClassNameMatches(int entity, const char[] className, bool part
  * @param class			Name String.
  * @return				True if the name matches, false otherwise.
  */
-stock bool Entity_NameMatches(int intentity, const char[] name)
+stock bool Entity_NameMatches(int entity, const char[] name)
 {
 	char entity_name[128];
 	Entity_GetName(entity, entity_name, sizeof(entity_name));
@@ -531,7 +533,7 @@ stock void Entity_AddSpawnFlags(int entity, int flags)
  */
 stock void Entity_RemoveSpawnFlags(int entity, int flags)
 {
-	int spawnFlags = Entity_GetSpawnFlags(int entity);
+	int spawnFlags = Entity_GetSpawnFlags(entity);
 	spawnFlags &= ~flags;
 	Entity_SetSpawnFlags(entity, spawnFlags);
 }
@@ -720,7 +722,7 @@ stock int Entity_GetFlags(int entity)
  */
 stock void Entity_SetFlags(int entity, int flags)
 {
-	SetEntProp(int entity, Prop_Data, "m_fFlags", flags);
+	SetEntProp(entity, Prop_Data, "m_fFlags", flags);
 }
 
 /**
@@ -949,7 +951,7 @@ stock bool Entity_IsSolid(int entity)
  * @param size			max size of buffer string
  * @return				Number of non-null bytes written.
  */
-stock void Entity_GetModel(int entity, char[] buffer, int size)
+stock int Entity_GetModel(int entity, char[] buffer, int size)
 {
 	return GetEntPropString(entity, Prop_Data, "m_ModelName", buffer, size);
 }
@@ -1336,9 +1338,9 @@ stock int Entity_GetMaxHealth(int entity)
  *
  * @param entity		Entity index
  * @param value			Max health to set (anything above 511 will overload)
- * @noreturn
+ * @return				Value max health was set to
  */
-stock void Entity_SetMaxHealth(int entity, int value)
+stock int Entity_SetMaxHealth(int entity, int value)
 {
 	SetEntProp(entity, Prop_Data, "m_iMaxHealth", value);
 	return value;

--- a/scripting/include/smlib/files.inc
+++ b/scripting/include/smlib/files.inc
@@ -18,14 +18,14 @@
  * @param size			Size of string buffer
  * @noreturn
  */
-stock bool:File_GetBaseName(const String:path[], String:buffer[], size)
+stock void File_GetBaseName(const char[] path, char[] buffer, int size)
 {
 	if (path[0] == '\0') {
 		buffer[0] = '\0';
 		return;
 	}
 
-	new pos_start = FindCharInString(path, '/', true);
+	int pos_start = FindCharInString(path, '/', true);
 
 	if (pos_start == -1) {
 		pos_start = FindCharInString(path, '\\', true);
@@ -48,14 +48,14 @@ stock bool:File_GetBaseName(const String:path[], String:buffer[], size)
  * @param size			Size of string buffer
  * @noreturn
  */
-stock bool:File_GetDirName(const String:path[], String:buffer[], size)
+stock void File_GetDirName(const char[] path, char[] buffer, int size)
 {
 	if (path[0] == '\0') {
 		buffer[0] = '\0';
 		return;
 	}
 
-	new pos_start = FindCharInString(path, '/', true);
+	int pos_start = FindCharInString(path, '/', true);
 
 	if (pos_start == -1) {
 		pos_start = FindCharInString(path, '\\', true);
@@ -80,7 +80,7 @@ stock bool:File_GetDirName(const String:path[], String:buffer[], size)
  * @param size			Size of string buffer
  * @noreturn
  */
-stock bool:File_GetFileName(const String:path[], String:buffer[], size)
+stock void File_GetFileName(const char[] path, char[] buffer, int size)
 {
 	if (path[0] == '\0') {
 		buffer[0] = '\0';
@@ -89,7 +89,7 @@ stock bool:File_GetFileName(const String:path[], String:buffer[], size)
 
 	File_GetBaseName(path, buffer, size);
 
-	new pos_ext = FindCharInString(buffer, '.', true);
+	int pos_ext = FindCharInString(buffer, '.', true);
 
 	if (pos_ext != -1) {
 		buffer[pos_ext] = '\0';
@@ -107,9 +107,9 @@ stock bool:File_GetFileName(const String:path[], String:buffer[], size)
  * @param size			Max length of string buffer
  * @noreturn
  */
-stock File_GetExtension(const String:path[], String:buffer[], size)
+stock void File_GetExtension(const char[] path, char[] buffer, int size)
 {
-	new extpos = FindCharInString(path, '.', true);
+	int extpos = FindCharInString(path, '.', true);
 
 	if (extpos == -1) {
 		buffer[0] = '\0';
@@ -130,14 +130,14 @@ stock File_GetExtension(const String:path[], String:buffer[], size)
  *
  * @param path			Path String
  * @param recursive		Whether to do recursion or not.
- * @param ignoreExts	Optional: 2 dimensional String array.You can define it like this: new String:ignore[][] = { ".ext1", ".ext2" };
+ * @param ignoreExts	Optional: 2 dimensional String array.You can define it like this: char ignore[][] = { ".ext1", ".ext2" };
  * @param size			This should be set to the number of file extensions in the ignoreExts array (sizeof(ignore) for the example above)
  * @noreturn
  */
 
 // Damn you SourcePawn :( I didn't want to
-new String:_smlib_empty_twodimstring_array[][] = { { '\0' } };
-stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const String:ignoreExts[][]=_smlib_empty_twodimstring_array, size=0)
+char _smlib_empty_twodimstring_array[][] = { { '\0' } };
+stock void File_AddToDownloadsTable(const char[] path, bool recursive=true, const char ignoreExts[][]=_smlib_empty_twodimstring_array, int size=0)
 {
 	if (path[0] == '\0') {
 		return;
@@ -145,7 +145,7 @@ stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const S
 
 	if (FileExists(path)) {
 
-		new String:fileExtension[5];
+		char fileExtension[4];
 		File_GetExtension(path, fileExtension, sizeof(fileExtension));
 
 		if (StrEqual(fileExtension, "bz2", false) || StrEqual(fileExtension, "ztmp", false)) {
@@ -156,7 +156,7 @@ stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const S
 			return;
 		}
 
-		decl String:path_new[PLATFORM_MAX_PATH];
+		char path_new[PLATFORM_MAX_PATH];
 		strcopy(path_new, sizeof(path_new), path);
 		ReplaceString(path_new, sizeof(path_new), "//", "/");
 
@@ -164,10 +164,10 @@ stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const S
 	}
 	else if (recursive && DirExists(path)) {
 
-		decl String:dirEntry[PLATFORM_MAX_PATH];
-		new Handle:__dir = OpenDirectory(path);
+		char dirEntry[PLATFORM_MAX_PATH];
+		DirectoryListing __dir = OpenDirectory(path);
 
-		while (ReadDirEntry(__dir, dirEntry, sizeof(dirEntry))) {
+		while (__dir.GetNext(dirEntry, sizeof(dirEntry))) {
 
 			if (StrEqual(dirEntry, ".") || StrEqual(dirEntry, "..")) {
 				continue;
@@ -177,26 +177,23 @@ stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const S
 			File_AddToDownloadsTable(dirEntry, recursive, ignoreExts, size);
 		}
 
-		CloseHandle(__dir);
+		delete __dir;
 	}
 	else if (FindCharInString(path, '*', true)) {
 
-		new String:fileExtension[4];
+		char fileExtension[4];
 		File_GetExtension(path, fileExtension, sizeof(fileExtension));
 
 		if (StrEqual(fileExtension, "*")) {
 
-			decl
-				String:dirName[PLATFORM_MAX_PATH],
-				String:fileName[PLATFORM_MAX_PATH],
-				String:dirEntry[PLATFORM_MAX_PATH];
+			char dirName[PLATFORM_MAX_PATH], fileName[PLATFORM_MAX_PATH], dirEntry[PLATFORM_MAX_PATH];
 
 			File_GetDirName(path, dirName, sizeof(dirName));
 			File_GetFileName(path, fileName, sizeof(fileName));
 			StrCat(fileName, sizeof(fileName), ".");
 
-			new Handle:__dir = OpenDirectory(dirName);
-			while (ReadDirEntry(__dir, dirEntry, sizeof(dirEntry))) {
+			DirectoryListing __dir = OpenDirectory(dirName);
+			while (__dir.GetNext(dirEntry, sizeof(dirEntry))) {
 
 				if (StrEqual(dirEntry, ".") || StrEqual(dirEntry, "..")) {
 					continue;
@@ -208,7 +205,7 @@ stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const S
 				}
 			}
 
-			CloseHandle(__dir);
+			delete __dir;
 		}
 	}
 
@@ -224,19 +221,19 @@ stock File_AddToDownloadsTable(const String:path[], bool:recursive=true, const S
  * @param path			Path to the .txt file.
  * @noreturn
  */
-stock File_ReadDownloadList(const String:path[])
+stock void File_ReadDownloadList(const char[] path)
 {
-	new Handle:file = OpenFile(path, "r");
+	File file = OpenFile(path, "r");
 
-	if (file  == INVALID_HANDLE) {
+	if (file == null) {
 		return;
 	}
 
-	new String:buffer[PLATFORM_MAX_PATH];
-	while (!IsEndOfFile(file)) {
-		ReadFileLine(file, buffer, sizeof(buffer));
+	char buffer[PLATFORM_MAX_PATH];
+	while (!file.EndOfFile()) {
+		file.ReadLine(buffer, sizeof(buffer));
 
-		new pos;
+		int pos;
 		pos = StrContains(buffer, "//");
 		if (pos != -1) {
 			buffer[pos] = '\0';
@@ -261,7 +258,7 @@ stock File_ReadDownloadList(const String:path[])
 		File_AddToDownloadsTable(buffer);
 	}
 
-	CloseHandle(file);
+	delete file;
 }
 
 /*
@@ -272,9 +269,9 @@ stock File_ReadDownloadList(const String:path[])
  * @param setFailState	If true, it sets the failstate if the translations file doesn't exist
  * @return				True on success, false otherwise (only if setFailState is set to false)
  */
-stock File_LoadTranslations(const String:file[], setFailState=true)
+stock bool File_LoadTranslations(const char[] file)
 {
-	decl String:path[PLATFORM_MAX_PATH];
+	char path[PLATFORM_MAX_PATH];
 
 	BuildPath(Path_SM, path, sizeof(path), "translations/%s", file);
 
@@ -283,7 +280,7 @@ stock File_LoadTranslations(const String:file[], setFailState=true)
 		return true;
 	}
 
-	Format(path,sizeof(path), "%s.txt", path);
+	Format(path, sizeof(path), "%s.txt", path);
 
 	if (!FileExists(path)) {
 
@@ -307,17 +304,17 @@ stock File_LoadTranslations(const String:file[], setFailState=true)
  * @param size		If -1, reads until a null terminator is encountered in the file.  Otherwise, read_count bytes are read into the buffer provided.  In this case the buffer is not explicitly null terminated, and the buffer will contain any null terminators read from the file.
  * @return			Number of characters written to the buffer, or -1 if an error was encountered.
  */
-stock File_ToString(const String:path[], String:buffer[], size)
+stock int File_ToString(const char[] path, char[] buffer, int size)
 {
-	new Handle:file = OpenFile(path, "rb");
+	File file = OpenFile(path, "rb");
 
-	if (file == INVALID_HANDLE) {
+	if (file == null) {
 		buffer[0] = '\0';
 		return -1;
 	}
 
-	new num_bytes_written = ReadFileString(file, buffer, size);
-	CloseHandle(file);
+	int num_bytes_written = file.ReadString(buffer, size);
+	delete file;
 
 	return num_bytes_written;
 }
@@ -329,16 +326,16 @@ stock File_ToString(const String:path[], String:buffer[], size)
  * @param str		String to write
  * @return			True on success, false otherwise
  */
-stock bool:File_StringToFile(const String:path[], String:str[])
+stock bool File_StringToFile(const char[] path, char[] str)
 {
-	new Handle:file = OpenFile(path, "wb");
+	File file = OpenFile(path, "wb");
 
-	if (file == INVALID_HANDLE) {
+	if (file == null) {
 		return false;
 	}
 
-	new bool:success = WriteFileString(file, str, false);
-	CloseHandle(file);
+	bool success = file.WriteString(str, false);
+	delete file;
 
 	return success;
 }
@@ -351,31 +348,31 @@ stock bool:File_StringToFile(const String:path[], String:str[])
  * @param source		Input file
  * @param destination	Output file
  */
-stock bool:File_Copy(const String:source[], const String:destination[])
+stock bool File_Copy(const char[] source, const char[] destination)
 {
-	new Handle:file_source = OpenFile(source, "rb");
+	File file_source = OpenFile(source, "rb");
 
-	if (file_source == INVALID_HANDLE) {
+	if (file_source == null) {
 		return false;
 	}
 
-	new Handle:file_destination = OpenFile(destination, "wb");
+	File file_destination = OpenFile(destination, "wb");
 
-	if (file_destination == INVALID_HANDLE) {
-		CloseHandle(file_source);
+	if (file_destination == null) {
+		delete file_source;
 		return false;
 	}
 
-	new buffer[32];
-	new cache;
+	int buffer[32];
+	int cache;
 
-	while (!IsEndOfFile(file_source)) {
-		cache = ReadFile(file_source, buffer, 32, 1);
-		WriteFile(file_destination, buffer, cache, 1);
+	while (!file_source.EndOfFile()) {
+		cache = file_source.Read(buffer, 32, 1);
+		file_destination.Write(buffer, cache, 1);
 	}
 
-	CloseHandle(file_source);
-	CloseHandle(file_destination);
+	delete file_source;
+	delete file_destination;
 
 	return true;
 }
@@ -392,7 +389,7 @@ stock bool:File_Copy(const String:source[], const String:destination[])
  * @param stop_on_error	Optional: Set to true to stop on error (ie can't read a file)
  * @param dirMode		Optional: File mode for directories that will be created (Default = 0755), don't forget to convert FROM octal
  */
-stock bool:File_CopyRecursive(const String:path[], const String:destination[], bool:stop_on_error=false, dirMode=493)
+stock bool File_CopyRecursive(const char[] path, const char[] destination, bool stop_on_error=false, int dirMode=493)
 {
 	if (FileExists(path)) {
 		return File_Copy(path, destination);
@@ -405,7 +402,7 @@ stock bool:File_CopyRecursive(const String:path[], const String:destination[], b
 	}
 }
 
-static stock bool:Sub_File_CopyRecursive(const String:path[], const String:destination[], bool:stop_on_error=false, FileType:fileType, dirMode)
+static stock bool Sub_File_CopyRecursive(const char[] path, const char[] destination, bool stop_on_error=false, FileType fileType, int dirMode)
 {
 	if (fileType == FileType_File) {
 		return File_Copy(path, destination);
@@ -416,18 +413,16 @@ static stock bool:Sub_File_CopyRecursive(const String:path[], const String:desti
 			return false;
 		}
 
-		new Handle:directory = OpenDirectory(path);
+		DirectoryListing directory = OpenDirectory(path);
 
-		if (directory == INVALID_HANDLE) {
+		if (directory == null) {
 			return false;
 		}
 
-		decl
-			String:source_buffer[PLATFORM_MAX_PATH],
-			String:destination_buffer[PLATFORM_MAX_PATH];
-		new FileType:type;
+		char source_buffer[PLATFORM_MAX_PATH], destination_buffer[PLATFORM_MAX_PATH];
+		FileType type;
 
-		while (ReadDirEntry(directory, source_buffer, sizeof(source_buffer), type)) {
+		while (directory.GetNext(source_buffer, sizeof(source_buffer), type)) {
 
 			if (StrEqual(source_buffer, "..") || StrEqual(source_buffer, ".")) {
 				continue;
@@ -442,13 +437,13 @@ static stock bool:Sub_File_CopyRecursive(const String:path[], const String:desti
 			else if (type == FileType_Directory) {
 
 				if (!File_CopyRecursive(source_buffer, destination_buffer, stop_on_error, dirMode) && stop_on_error) {
-					CloseHandle(directory);
+					delete directory;
 					return false;
 				}
 			}
 		}
 
-		CloseHandle(directory);
+		delete directory;
 	}
 	else if (fileType == FileType_Unknown) {
 		return false;

--- a/scripting/include/smlib/files.inc
+++ b/scripting/include/smlib/files.inc
@@ -269,7 +269,7 @@ stock void File_ReadDownloadList(const char[] path)
  * @param setFailState	If true, it sets the failstate if the translations file doesn't exist
  * @return				True on success, false otherwise (only if setFailState is set to false)
  */
-stock bool File_LoadTranslations(const char[] file)
+stock bool File_LoadTranslations(const char[] file, const bool setFailState=false)
 {
 	char path[PLATFORM_MAX_PATH];
 

--- a/scripting/include/smlib/game.inc
+++ b/scripting/include/smlib/game.inc
@@ -13,9 +13,9 @@
  * @noparam
  * @return				True on success, false otherwise
  */
-stock bool:Game_End()
+stock bool Game_End()
 {
-	new game_end = FindEntityByClassname(-1, "game_end");
+	int game_end = FindEntityByClassname(-1, "game_end");
 
 	if (game_end == -1) {
 		game_end = CreateEntityByName("game_end");
@@ -38,9 +38,9 @@ stock bool:Game_End()
  * @param switchTeams	If to switch the teams when the game is going to be reset.
  * @return				True on success, false otherwise
  */
-stock bool:Game_EndRound(team=0, bool:forceMapReset=false, bool:switchTeams=false)
+stock bool Game_EndRound(int team=0, bool forceMapReset=false, bool switchTeams=false)
 {
-	new game_round_win = FindEntityByClassname(-1, "game_round_win");
+	int game_round_win = FindEntityByClassname(-1, "game_round_win");
 
 	if (game_round_win == -1) {
 		game_round_win = CreateEntityByName("game_round_win");

--- a/scripting/include/smlib/general.inc
+++ b/scripting/include/smlib/general.inc
@@ -18,9 +18,9 @@
  * @param material			Path of the material to precache.
  * @return					Returns the material index, INVALID_STRING_INDEX on error.
  */
-stock PrecacheMaterial(const String:material[])
+stock int PrecacheMaterial(const char[] material)
 {
-	static materialNames = INVALID_STRING_TABLE;
+	static int materialNames = INVALID_STRING_TABLE;
 
 	if (materialNames == INVALID_STRING_TABLE) {
 		if ((materialNames = FindStringTable("Materials")) == INVALID_STRING_TABLE) {
@@ -28,9 +28,9 @@ stock PrecacheMaterial(const String:material[])
 		}
 	}
 
-	new index = FindStringIndex2(materialNames, material);
+	int index = FindStringIndex2(materialNames, material);
 	if (index == INVALID_STRING_INDEX) {
-		new numStrings = GetStringTableNumStrings(materialNames);
+		int numStrings = GetStringTableNumStrings(materialNames);
 		if (numStrings >= GetStringTableMaxStrings(materialNames)) {
 			return INVALID_STRING_INDEX;
 		}
@@ -48,9 +48,9 @@ stock PrecacheMaterial(const String:material[])
  * @param material			Path of the material.
  * @return					True if it is precached, false otherwise.
  */
-stock bool:IsMaterialPrecached(const String:material[])
+stock bool IsMaterialPrecached(const char[] material)
 {
-	static materialNames = INVALID_STRING_TABLE;
+	static int materialNames = INVALID_STRING_TABLE;
 
 	if (materialNames == INVALID_STRING_TABLE) {
 		if ((materialNames = FindStringTable("Materials")) == INVALID_STRING_TABLE) {
@@ -69,9 +69,9 @@ stock bool:IsMaterialPrecached(const String:material[])
  * @param particleSystem	Name of the particle system to precache.
  * @return					Returns the particle system index, INVALID_STRING_INDEX on error.
  */
-stock PrecacheParticleSystem(const String:particleSystem[])
+stock int PrecacheParticleSystem(const char[] particleSystem)
 {
-	static particleEffectNames = INVALID_STRING_TABLE;
+	static int particleEffectNames = INVALID_STRING_TABLE;
 
 	if (particleEffectNames == INVALID_STRING_TABLE) {
 		if ((particleEffectNames = FindStringTable("ParticleEffectNames")) == INVALID_STRING_TABLE) {
@@ -79,9 +79,9 @@ stock PrecacheParticleSystem(const String:particleSystem[])
 		}
 	}
 
-	new index = FindStringIndex2(particleEffectNames, particleSystem);
+	int index = FindStringIndex2(particleEffectNames, particleSystem);
 	if (index == INVALID_STRING_INDEX) {
-		new numStrings = GetStringTableNumStrings(particleEffectNames);
+		int numStrings = GetStringTableNumStrings(particleEffectNames);
 		if (numStrings >= GetStringTableMaxStrings(particleEffectNames)) {
 			return INVALID_STRING_INDEX;
 		}
@@ -99,7 +99,7 @@ stock PrecacheParticleSystem(const String:particleSystem[])
  * @param material			Name of the particle system
  * @return					True if it is precached, false otherwise.
  */
-stock bool:IsParticleSystemPrecached(const String:particleSystem[])
+stock bool IsParticleSystemPrecached(const char[] particleSystem)
 {
 	static particleEffectNames = INVALID_STRING_TABLE;
 
@@ -119,9 +119,9 @@ stock bool:IsParticleSystemPrecached(const String:particleSystem[])
  * @param str			String to find.
  * @return				String index if found, INVALID_STRING_INDEX otherwise.
  */
-stock FindStringIndexByTableName(const String:table[], const String:str[])
+stock int FindStringIndexByTableName(const char[] table, const char[] str)
 {
-	new tableIndex = INVALID_STRING_TABLE;
+	int tableIndex = INVALID_STRING_TABLE;
 	if ((tableIndex = FindStringTable("ParticleEffectNames")) == INVALID_STRING_TABLE) {
 		return INVALID_STRING_INDEX;
 	}
@@ -138,12 +138,12 @@ stock FindStringIndexByTableName(const String:table[], const String:str[])
  * @param str			String to find.
  * @return				String index if found, INVALID_STRING_INDEX otherwise.
  */
-stock FindStringIndex2(tableidx, const String:str[])
+stock int FindStringIndex2(int tableidx, const char[] str)
 {
-	decl String:buf[1024];
+	char buf[1024];
 
-	new numStrings = GetStringTableNumStrings(tableidx);
-	for (new i=0; i < numStrings; i++) {
+	int numStrings = GetStringTableNumStrings(tableidx);
+	for (int i=0; i < numStrings; i++) {
 		ReadStringTable(tableidx, i, buf, sizeof(buf));
 
 		if (StrEqual(buf, str)) {
@@ -162,7 +162,7 @@ stock FindStringIndex2(tableidx, const String:str[])
  * @param size			String Buffer size
  * @noreturn
  */
-stock LongToIP(ip, String:buffer[], size)
+stock void LongToIP(int ip, char[] buffer, int size)
 {
 	Format(
 		buffer, size,
@@ -180,9 +180,9 @@ stock LongToIP(ip, String:buffer[], size)
  * @param ip			IP String
  * @return				Long IP
  */
-stock IPToLong(const String:ip[])
+stock int IPToLong(const char[] ip)
 {
-	decl String:pieces[4][4];
+	char pieces[4][4];
 
 	if (ExplodeString(ip, ".", pieces, sizeof(pieces), sizeof(pieces[])) != 4) {
 		return 0;
@@ -196,7 +196,7 @@ stock IPToLong(const String:ip[])
 	);
 }
 
-static localIPRanges[] =
+static int localIPRanges[] =
 {
 	10	<< 24,				// 10.
 	127	<< 24 | 1		,	// 127.0.0.1
@@ -210,16 +210,17 @@ static localIPRanges[] =
  * @param ip			IP Long
  * @return				True if the IP is local, false otherwise.
  */
-stock bool:IsIPLocal(ip)
+stock bool IsIPLocal(int ip)
 {
-	new range, bits, move, bool:matches;
+	int range, bits, move;
+	bool matches;
 
-	for (new i=0; i < sizeof(localIPRanges); i++) {
+	for (int i=0; i < sizeof(localIPRanges); i++) {
 
 		range = localIPRanges[i];
 		matches = true;
 
-		for (new j=0; j < 4; j++) {
+		for (int j=0; j < 4; j++) {
 			move = j * 8;
 			bits = (range >> move) & 0xFF;
 
@@ -237,15 +238,14 @@ stock bool:IsIPLocal(ip)
 }
 
 /*
- * Closes the given hindle and sets it to INVALID_HANDLE.
+ * Closes the given hindle and sets it to null.
  *
  * @param handle   handle
  * @noreturn
  */
-stock ClearHandle(&Handle:handle)
+stock void ClearHandle(Handle &handle)
 {
-	if (handle != INVALID_HANDLE) {
-		CloseHandle(handle);
-		handle = INVALID_HANDLE;
+	if (handle != null) {
+		delete handle;
 	}
 }

--- a/scripting/include/smlib/general.inc
+++ b/scripting/include/smlib/general.inc
@@ -101,7 +101,7 @@ stock int PrecacheParticleSystem(const char[] particleSystem)
  */
 stock bool IsParticleSystemPrecached(const char[] particleSystem)
 {
-	static particleEffectNames = INVALID_STRING_TABLE;
+	static int particleEffectNames = INVALID_STRING_TABLE;
 
 	if (particleEffectNames == INVALID_STRING_TABLE) {
 		if ((particleEffectNames = FindStringTable("ParticleEffectNames")) == INVALID_STRING_TABLE) {

--- a/scripting/include/smlib/math.inc
+++ b/scripting/include/smlib/math.inc
@@ -29,7 +29,7 @@ enum VecAngle
  * @param number		A number that can be positive or negative.
  * @return				Positive number.
  */
-stock Math_Abs(value)
+stock any Math_Abs(any number)
 {
 	return (value ^ (value >> 31)) - (value >> 31);
 }
@@ -43,9 +43,9 @@ stock Math_Abs(value)
  * @param tolerance 	If you want to check that those vectors are somewhat even. 0.0 means they are 100% even if this function returns true.
  * @return				True if vectors are equal, false otherwise.
  */
-stock bool:Math_VectorsEqual(Float:vec1[3], Float:vec2[3], Float:tolerance=0.0)
+stock bool Math_VectorsEqual(float vec1[3], float vec2[3], float tolerance=0.0)
 {
-	new Float:distance = GetVectorDistance(vec1, vec2, true);
+	float distance = GetVectorDistance(vec1, vec2, true);
 
 	return distance <= (tolerance * tolerance);
 }
@@ -58,7 +58,7 @@ stock bool:Math_VectorsEqual(Float:vec1[3], Float:vec2[3], Float:tolerance=0.0)
  * @param min			Min Value used as lower border
  * @return				Correct value not lower than min
  */
-stock any:Math_Min(any:value, any:min)
+stock any Math_Min(any value, any min)
 {
 	if (value < min) {
 		value = min;
@@ -75,7 +75,7 @@ stock any:Math_Min(any:value, any:min)
  * @param max			Max Value used as upper border
  * @return				Correct value not upper than max
  */
-stock any:Math_Max(any:value, any:max)
+stock any Math_Max(any value, any max)
 {
 	if (value > max) {
 		value = max;
@@ -96,7 +96,7 @@ stock any:Math_Max(any:value, any:max)
  * @param max			Max value used as upper border
  * @return				Correct value not lower than min and not greater than max.
  */
-stock any:Math_Clamp(any:value, any:min, any:max)
+stock any Math_Clamp(any value, any min, any max)
 {
 	value = Math_Min(value, min);
 	value = Math_Max(value, max);
@@ -112,7 +112,7 @@ stock any:Math_Clamp(any:value, any:min, any:max)
  * @param max		The upper border.
  * @return			True if the value is within bounds (bigger or equal min / smaller or equal max), false otherwise.
  */
-stock bool:Math_IsInBounds(any:value, any:min, any:max)
+stock bool Math_IsInBounds(any value, any min, any max)
 {
 	if (value < min || value > max) {
 		return false;
@@ -131,7 +131,7 @@ stock bool:Math_IsInBounds(any:value, any:min, any:max)
  * @param max			Max value used as upper border
  * @return				Overflowed number
  */
-stock any:Math_Overflow(any:value, any:min, any:max)
+stock any Math_Overflow(any value, any min, any max)
 {
 	return (value % max) + min;
 }
@@ -146,9 +146,9 @@ stock any:Math_Overflow(any:value, any:min, any:max)
  * @param max			Max value used as upper border
  * @return				Random Integer number between min and max
  */
-stock Math_GetRandomInt(min, max)
+stock int Math_GetRandomInt(int min, int max)
 {
-	new random = GetURandomInt();
+	int random = GetURandomInt();
 
 	if (random == 0) {
 		random++;
@@ -166,7 +166,7 @@ stock Math_GetRandomInt(min, max)
  * @param max			Max value used as upper border
  * @return				Random Float number between min and max
  */
-stock Float:Math_GetRandomFloat(Float:min, Float:max)
+stock float Math_GetRandomFloat(float min, float max)
 {
 	return (GetURandomFloat() * (max  - min)) + min;
 }
@@ -180,7 +180,7 @@ stock Float:Math_GetRandomFloat(Float:min, Float:max)
  * @param all			Integer value
  * @return				An Integer value between 0 and 100 (inclusive).
  */
-stock Math_GetPercentage(value, all) {
+stock int Math_GetPercentage(int value, int all) {
 	return RoundToNearest((float(value) / float(all)) * 100.0);
 }
 
@@ -193,7 +193,7 @@ stock Math_GetPercentage(value, all) {
  * @param all			Float value
  * @return				A Float value between 0.0 and 100.0 (inclusive).
  */
-stock Float:Math_GetPercentageFloat(Float:value, Float:all) {
+stock float Math_GetPercentageFloat(float value, float all) {
 	return (value / all) * 100.0;
 }
 
@@ -208,7 +208,7 @@ stock Float:Math_GetPercentageFloat(Float:value, Float:all) {
  * @param output		Output vector
  * @noreturn
  */
-stock Math_MoveVector(const Float:start[3], const Float:end[3], Float:scale, Float:output[3])
+stock void Math_MoveVector(const float start[3], const float end[3], float scale, float output[3])
 {
 	SubtractVectors(end,start,output);
 	ScaleVector(output,scale);
@@ -224,7 +224,7 @@ stock Math_MoveVector(const Float:start[3], const Float:end[3], Float:scale, Flo
  * @param result		Output vector.
  * @noreturn
  */
-stock Math_MakeVector(const Float:x, const Float:y, const Float:z, Float:result[3])
+stock void Math_MakeVector(const float x, const float y, const float z, float result[3])
 {
 	result[0] = x;
 	result[1] = y;
@@ -244,10 +244,10 @@ stock Math_MakeVector(const Float:x, const Float:y, const Float:z, Float:result[
  * @param result		Output vector.
  * @noreturn
  */
-stock Math_RotateVector(const Float:vec[3], const Float:angles[3], Float:result[3])
+stock void Math_RotateVector(const float vec[3], const float angles[3], float result[3])
 {
 	// First the angle/radiant calculations
-	decl Float:rad[3];
+	float rad[3];
 	// I don't really know why, but the alpha, beta, gamma order of the angles are messed up...
 	// 2 = xAxis
 	// 0 = yAxis
@@ -257,16 +257,16 @@ stock Math_RotateVector(const Float:vec[3], const Float:angles[3], Float:result[
 	rad[2] = DegToRad(angles[1]);
 
 	// Pre-calc function calls
-	new Float:cosAlpha = Cosine(rad[0]);
-	new Float:sinAlpha = Sine(rad[0]);
-	new Float:cosBeta = Cosine(rad[1]);
-	new Float:sinBeta = Sine(rad[1]);
-	new Float:cosGamma = Cosine(rad[2]);
-	new Float:sinGamma = Sine(rad[2]);
+	float cosAlpha = Cosine(rad[0]);
+	float sinAlpha = Sine(rad[0]);
+	float cosBeta = Cosine(rad[1]);
+	float sinBeta = Sine(rad[1]);
+	float cosGamma = Cosine(rad[2]);
+	float sinGamma = Sine(rad[2]);
 
 	// 3D rotation matrix for more information: http://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
-	new Float:x = vec[0], Float:y = vec[1], Float:z = vec[2];
-	new Float:newX, Float:newY, Float:newZ;
+	float x = vec[0], y = vec[1], z = vec[2];
+	float newX, newY, newZ;
 	newY = cosAlpha*y - sinAlpha*z;
 	newZ = cosAlpha*z + sinAlpha*y;
 	y = newY;
@@ -294,7 +294,7 @@ stock Math_RotateVector(const Float:vec[3], const Float:angles[3], Float:result[
  * @param units			Float value
  * @return				Meters as Float value.
  */
-stock Float:Math_UnitsToMeters(Float:units)
+stock float Math_UnitsToMeters(float units)
 {
 	return (units * GAMEUNITS_TO_METERS);
 }
@@ -305,7 +305,7 @@ stock Float:Math_UnitsToMeters(Float:units)
  * @param units			Float value
  * @return				Feet as Float value.
  */
-stock Float:Math_UnitsToFeet(Float:units)
+stock float Math_UnitsToFeet(float units)
 {
 	return (Math_UnitsToMeters(units) * METERS_TO_FEET);
 }
@@ -316,7 +316,7 @@ stock Float:Math_UnitsToFeet(Float:units)
  * @param units			Float value
  * @return				Centimeters as Float value.
  */
-stock Float:Math_UnitsToCentimeters(Float:units)
+stock float Math_UnitsToCentimeters(float units)
 {
 	return (Math_UnitsToMeters(units) * 100.0);
 }
@@ -327,7 +327,7 @@ stock Float:Math_UnitsToCentimeters(Float:units)
  * @param units			Float value
  * @return				Kilometers as Float value.
  */
-stock Float:Math_UnitsToKilometers(Float:units)
+stock float Math_UnitsToKilometers(float units)
 {
 	return (Math_UnitsToMeters(units) / 1000.0);
 }
@@ -338,7 +338,7 @@ stock Float:Math_UnitsToKilometers(Float:units)
  * @param units			Float value
  * @return				Miles as Float value.
  */
-stock Float:Math_UnitsToMiles(Float:units)
+stock float Math_UnitsToMiles(float units)
 {
 	return (Math_UnitsToKilometers(units) * KILOMETERS_TO_MILES);
 }

--- a/scripting/include/smlib/math.inc
+++ b/scripting/include/smlib/math.inc
@@ -29,7 +29,7 @@ enum VecAngle
  * @param number		A number that can be positive or negative.
  * @return				Positive number.
  */
-stock any Math_Abs(any number)
+stock any Math_Abs(any value)
 {
 	return (value ^ (value >> 31)) - (value >> 31);
 }

--- a/scripting/include/smlib/menus.inc
+++ b/scripting/include/smlib/menus.inc
@@ -15,11 +15,11 @@
  * @param   display     Display text for the menu
  * @noreturn
  */
-stock Menu_AddIntItem(Handle:menu, any:value, String:display[])
+stock void Menu_AddIntItem(Menu menu, any value, char[] display)
 {
-	decl String:buffer[INT_MAX_DIGITS + 1];
+	char buffer[INT_MAX_DIGITS + 1];
 	IntToString(value, buffer, sizeof(buffer));
-	AddMenuItem(menu, buffer, display);
+	menu.AddItem(buffer, display);
 }
 
 /**
@@ -30,9 +30,9 @@ stock Menu_AddIntItem(Handle:menu, any:value, String:display[])
  * @param   param2       The item position selected from the menu.
  * @return               Integer choice from the menu, or 0 if the integer could not be parsed.
  */
-stock any:Menu_GetIntItem(Handle:menu, any:param2)
+stock any Menu_GetIntItem(Menu menu, any param2)
 {
-	decl String:buffer[INT_MAX_DIGITS + 1];
-	GetMenuItem(menu, param2, buffer, sizeof(buffer));
+	char buffer[INT_MAX_DIGITS + 1];
+	menu.GetItem(param2, buffer, sizeof(buffer));
 	return StringToInt(buffer);
 }

--- a/scripting/include/smlib/server.inc
+++ b/scripting/include/smlib/server.inc
@@ -17,19 +17,19 @@
  * @param public		Set to true to retrieve the server's public/external IP, false otherwise.
  * @return				Long IP or 0 if the IP couldn't be retrieved.
  */
-stock Server_GetIP(bool:public_=true)
+stock int Server_GetIP(bool public_=true)
 {
-	new ip = 0;
+	int ip = 0;
 
-	static Handle:cvHostip = INVALID_HANDLE;
+	static ConVar cvHostip;
 
-	if (cvHostip == INVALID_HANDLE) {
+	if (cvHostip == null) {
 		cvHostip = FindConVar("hostip");
 		MarkNativeAsOptional("Steam_GetPublicIP");
 	}
 
-	if (cvHostip != INVALID_HANDLE) {
-		ip = GetConVarInt(cvHostip);
+	if (cvHostip != null) {
+		ip = cvHostip.IntValue;
 	}
 
 	if (ip != 0 && IsIPLocal(ip) == public_) {
@@ -39,7 +39,7 @@ stock Server_GetIP(bool:public_=true)
 #if defined _steamtools_included
 	if (ip == 0) {
 		if (CanTestFeatures() && GetFeatureStatus(FeatureType_Native, "Steam_GetPublicIP") == FeatureStatus_Available) {
-			decl octets[4];
+			int octets[4];
 			Steam_GetPublicIP(octets);
 
 			ip =
@@ -72,9 +72,9 @@ stock Server_GetIP(bool:public_=true)
  * @param public		Set to true to retrieve the server's public/external IP, false otherwise.
  * @return				True on success, false otherwise.
  */
-stock bool:Server_GetIPString(String:buffer[], size, bool:public_=true)
+stock bool Server_GetIPString(char[] buffer, int size, bool public_=true)
 {
-	new ip;
+	int ip;
 
 	if ((ip = Server_GetIP(public_)) == 0) {
 		buffer[0] = '\0';
@@ -92,19 +92,19 @@ stock bool:Server_GetIPString(String:buffer[], size, bool:public_=true)
  * @noparam
  * @return			The server's port, 0 if there is no port.
  */
-stock Server_GetPort()
+stock int Server_GetPort()
 {
-	static Handle:cvHostport = INVALID_HANDLE;
+	static ConVar cvHostport;
 
-	if (cvHostport == INVALID_HANDLE) {
+	if (cvHostport == null) {
 		cvHostport = FindConVar("hostport");
 	}
 
-	if (cvHostport == INVALID_HANDLE) {
+	if (cvHostport == null) {
 		return 0;
 	}
 
-	new port = GetConVarInt(cvHostport);
+	int port = cvHostport.IntValue;
 
 	return port;
 }
@@ -116,20 +116,20 @@ stock Server_GetPort()
  * @param size			String buffer size
  * @return				True on success, false otherwise.
  */
-stock bool:Server_GetHostName(String:buffer[], size)
+stock bool Server_GetHostName(char[] buffer, int size)
 {
-	static Handle:cvHostname = INVALID_HANDLE;
+	static ConVar cvHostname;
 
-	if (cvHostname == INVALID_HANDLE) {
+	if (cvHostname == null) {
 		cvHostname = FindConVar("hostname");
 	}
 
-	if (cvHostname == INVALID_HANDLE) {
+	if (cvHostname == null) {
 		buffer[0] = '\0';
 		return false;
 	}
 
-	GetConVarString(cvHostname, buffer, size);
+	cvHostname.GetString(buffer, size);
 
 	return true;
 }

--- a/scripting/include/smlib/sql.inc
+++ b/scripting/include/smlib/sql.inc
@@ -19,14 +19,14 @@
  * @param ...			Variable number of format parameters.
  * @noreturn
  */
-stock SQL_TQueryF(Handle:database, SQLTCallback:callback, any:data, DBPriority:priority=DBPrio_Normal, const String:format[], any:...) {
+stock void SQL_TQueryF(Database database, SQLTCallback callback, any data, DBPriority priority=DBPrio_Normal, const char[] format, any ...) {
 
-	if (database == INVALID_HANDLE) {
+	if (database == null) {
 		ThrowError("[SMLIB] Error: Invalid database handle.");
 		return;
 	}
 
-	decl String:query[16384];
+	char query[16384];
 	VFormat(query, sizeof(query), format, 6);
 
 	SQL_TQuery(database, callback, query, data, priority);
@@ -43,9 +43,9 @@ stock SQL_TQueryF(Handle:database, SQLTCallback:callback, any:data, DBPriority:p
  *						type conversion requested from the database,
  *						or no current result set.
  */
-stock SQL_FetchIntByName(Handle:query, String:fieldName[], &DBResult:result=DBVal_Error) {
+stock int SQL_FetchIntByName(Handle query, char[] fieldName, DBResult &result=DBVal_Error) {
 
-	new fieldNum;
+	int fieldNum;
 	SQL_FieldNameToNum(query, fieldName, fieldNum);
 
 	return SQL_FetchInt(query, fieldNum, result);
@@ -62,9 +62,9 @@ stock SQL_FetchIntByName(Handle:query, String:fieldName[], &DBResult:result=DBVa
  *						type conversion requested from the database,
  *						or no current result set.
  */
-stock bool:SQL_FetchBoolByName(Handle:query, String:fieldName[], &DBResult:result=DBVal_Error) {
+stock bool SQL_FetchBoolByName(Handle query, char[] fieldName, DBResult &result=DBVal_Error) {
 
-	return bool:SQL_FetchIntByName(query, fieldName, result);
+	return view_as<bool>(SQL_FetchIntByName(query, fieldName, result));
 }
 
 /**
@@ -78,9 +78,9 @@ stock bool:SQL_FetchBoolByName(Handle:query, String:fieldName[], &DBResult:resul
  *						type conversion requested from the database,
  *						or no current result set.
  */
-stock Float:SQL_FetchFloatByName(Handle:query, String:fieldName[], &DBResult:result=DBVal_Error) {
+stock float SQL_FetchFloatByName(Handle query, char[] fieldName, DBResult &result=DBVal_Error) {
 
-	new fieldNum;
+	int fieldNum;
 	SQL_FieldNameToNum(query, fieldName, fieldNum);
 
 	return SQL_FetchFloat(query, fieldNum, result);
@@ -99,9 +99,9 @@ stock Float:SQL_FetchFloatByName(Handle:query, String:fieldName[], &DBResult:res
  *						type conversion requested from the database,
  *						or no current result set.
  */
-stock SQL_FetchStringByName(Handle:query, String:fieldName[], String:buffer[], maxlength, &DBResult:result=DBVal_Error) {
+stock int SQL_FetchStringByName(Handle query, char[] fieldName, char[] buffer, int maxlength, DBResult &result=DBVal_Error) {
 
-	new fieldNum;
+	int fieldNum;
 	SQL_FieldNameToNum(query, fieldName, fieldNum);
 
 	return SQL_FetchString(query, fieldNum, buffer, maxlength, result);

--- a/scripting/include/smlib/strings.inc
+++ b/scripting/include/smlib/strings.inc
@@ -13,11 +13,11 @@
  * @param str				String to check.
  * @return					True if the String is numeric, false otherwise..
  */
-stock bool:String_IsNumeric(const String:str[])
+stock bool String_IsNumeric(const char[] str)
 {
-	new x=0;
-	new dotsFound=0;
-	new numbersFound=0;
+	int x=0;
+	int dotsFound=0;
+	int numbersFound=0;
 
 	if (str[x] == '+' || str[x] == '-') {
 		x++;
@@ -60,9 +60,9 @@ stock bool:String_IsNumeric(const String:str[])
  * @param chars				Characters to remove.
  * @noreturn
  */
-stock String_Trim(const String:str[], String:output[], size, const String:chrs[]=" \t\r\n")
+stock void String_Trim(const char[] str, char[] output, int size, const char chrs[]=" \t\r\n")
 {
-	new x=0;
+	int x=0;
 	while (str[x] != '\0' && FindCharInString(chrs, str[x]) != -1) {
 		x++;
 	}
@@ -86,9 +86,9 @@ stock String_Trim(const String:str[], String:output[], size, const String:chrs[]
  * @param caseSensitive		If true, comparison is case sensitive. If false (default), comparison is case insensitive.
  * @noreturn
  */
-stock String_RemoveList(String:buffer[], String:removeList[][], size, bool:caseSensitive=false)
+stock void String_RemoveList(char[] buffer, char[][] removeList, int size, bool caseSensitive=false)
 {
-	for (new i=0; i < size; i++) {
+	for (int i=0; i < size; i++) {
 		ReplaceString(buffer, SIZE_OF_INT, removeList[i], "", caseSensitive);
 	}
 }
@@ -103,11 +103,11 @@ stock String_RemoveList(String:buffer[], String:removeList[][], size, bool:caseS
  * @param size				Max Size of the Output string
  * @noreturn
  */
-stock String_ToLower(const String:input[], String:output[], size)
+stock void String_ToLower(const char[] input, char[] output, int size)
 {
 	size--;
 
-	new x=0;
+	int x=0;
 	while (input[x] != '\0' && x < size) {
 
 		output[x] = CharToLower(input[x]);
@@ -128,11 +128,11 @@ stock String_ToLower(const String:input[], String:output[], size)
  * @param size				Max Size of the Output string
  * @noreturn
  */
-stock String_ToUpper(const String:input[], String:output[], size)
+stock void String_ToUpper(const char[] input, char[] output, int size)
 {
 	size--;
 
-	new x=0;
+	int x=0;
 	while (input[x] != '\0' && x < size) {
 
 		output[x] = CharToUpper(input[x]);
@@ -155,16 +155,16 @@ stock String_ToUpper(const String:input[], String:output[], size)
  * 							If you pass an empty String, it will use all readable ASCII characters (33 - 126)
  * @noreturn
  */
-stock String_GetRandom(String:buffer[], size, length=32, const String:chrs[]="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234556789")
+stock void String_GetRandom(char[] buffer, int size, int length=32, const char chrs[]="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234556789")
 {
-	new random, len;
+	int random, len;
 	size--;
 
 	if (chrs[0] != '\0') {
 		len = strlen(chrs) - 1;
 	}
 
-	new n = 0;
+	int n = 0;
 	while (n < length && n < size) {
 
 		if (chrs[0] == '\0') {
@@ -190,9 +190,9 @@ stock String_GetRandom(String:buffer[], size, length=32, const String:chrs[]="ab
  * @param subString			Sub-String to check in str
  * @return					True if str starts with subString, false otherwise.
  */
-stock bool:String_StartsWith(const String:str[], const String:subString[])
+stock bool String_StartsWith(const char[] str, const char[] subString)
 {
-	new n = 0;
+	int n = 0;
 	while (subString[n] != '\0') {
 
 		if (str[n] == '\0' || str[n] != subString[n]) {
@@ -213,10 +213,10 @@ stock bool:String_StartsWith(const String:str[], const String:subString[])
  * @param subString			Sub-String to check in str
  * @return					True if str ends with subString, false otherwise.
  */
-stock bool:String_EndsWith(const String:str[], const String:subString[])
+stock bool String_EndsWith(const char[] str, const char[] subString)
 {
-	new n_str = strlen(str) - 1;
-	new n_subString = strlen(subString) - 1;
+	int n_str = strlen(str) - 1;
+	int n_subString = strlen(subString) - 1;
 
 	if(n_str < n_subString) {
 		return false;

--- a/scripting/include/smlib/teams.inc
+++ b/scripting/include/smlib/teams.inc
@@ -25,10 +25,10 @@
  * @noparam
  * @return			True if one team is empty, false otherwise.
  */
-stock bool:Team_HaveAllPlayers(bool:countFakeClients=true) {
+stock bool Team_HaveAllPlayers(bool countFakeClients=true) {
 
-	new teamCount = GetTeamCount();
-	for (new i=2; i < teamCount; i++) {
+	int teamCount = GetTeamCount();
+	for (int i=2; i < teamCount; i++) {
 
 		if (Team_GetClientCount(i, ((countFakeClients) ? CLIENTFILTER_ALL : CLIENTFILTER_NOBOTS)) == 0) {
 			return false;
@@ -45,12 +45,12 @@ stock bool:Team_HaveAllPlayers(bool:countFakeClients=true) {
  * @param flags					Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @return						Client count in the server.
  */
-stock Team_GetClientCount(team, flags=0)
+stock int Team_GetClientCount(int team, int flags=0)
 {
 	flags |= CLIENTFILTER_INGAME;
 
-	new numClients = 0;
-	for (new client=1; client <= MaxClients; client++) {
+	int numClients = 0;
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!Client_MatchesFilter(client, flags)) {
 			continue;
@@ -74,11 +74,11 @@ stock Team_GetClientCount(team, flags=0)
  * @param flags					Client Filter Flags (Use the CLIENTFILTER_ constants).
  * @noreturn
  */
-stock Team_GetClientCounts(&team1=0, &team2=0, flags=0)
+stock void Team_GetClientCounts(int &team1=0, int &team2=0, int flags=0)
 {
 	flags |= CLIENTFILTER_INGAME;
 
-	for (new client=1; client <= MaxClients; client++) {
+	for (int client=1; client <= MaxClients; client++) {
 
 		if (!Client_MatchesFilter(client, flags)) {
 			continue;
@@ -102,9 +102,9 @@ stock Team_GetClientCounts(&team1=0, &team2=0, flags=0)
  * @param size			String Buffer Size
  * @return				True on success, false otherwise
  */
-stock bool:Team_GetName(index, String:str[], size)
+stock bool Team_GetName(int index, char[] str, int size)
 {
-	new edict = Team_GetEdict(index);
+	int edict = Team_GetEdict(index);
 
 	if (edict == -1) {
 		str[0] = '\0';
@@ -126,9 +126,9 @@ stock bool:Team_GetName(index, String:str[], size)
  * @param name			New Name String
  * @return				True on success, false otherwise
  */
-stock bool:Team_SetName(index, const String:name[])
+stock bool Team_SetName(int index, const char[] name)
 {
-	new edict = Team_GetEdict(index);
+	int edict = Team_GetEdict(index);
 
 	if (edict == -1) {
 		return false;
@@ -147,9 +147,9 @@ stock bool:Team_SetName(index, const String:name[])
  * @param index			Team Index.
  * @return				Team Score or -1 if the team is not valid.
  */
-stock Team_GetScore(index)
+stock int Team_GetScore(int index)
 {
-	new edict = Team_GetEdict(index);
+	int edict = Team_GetEdict(index);
 
 	if (edict == -1) {
 		return -1;
@@ -166,9 +166,9 @@ stock Team_GetScore(index)
  * @param score			Score value.
  * @return				True on success, false otherwise
  */
-stock bool:Team_SetScore(index, score)
+stock bool Team_SetScore(int index, int score)
 {
-	new edict = Team_GetEdict(index);
+	int edict = Team_GetEdict(index);
 
 	if (edict == -1) {
 		return false;
@@ -188,7 +188,7 @@ stock bool:Team_SetScore(index, score)
  * @param edict			Edict
  * @return				Team Index
  */
-stock Team_EdictGetNum(edict)
+stock int Team_EdictGetNum(int edict)
 {
 	return GetEntProp(edict, Prop_Send, "m_iTeamNum");
 }
@@ -200,7 +200,7 @@ stock Team_EdictGetNum(edict)
  * @param index			Index.
  * @return				True if the Index is a valid team, false otherwise.
  */
-stock bool:Team_IsValid(index)
+stock bool Team_IsValid(int index)
 {
 	return (Team_GetEdict(index) != -1);
 }
@@ -212,7 +212,7 @@ stock bool:Team_IsValid(index)
  * @param index			Edict
  * @return				Team Index
  */
-stock Team_EdictIsValid(edict)
+stock int Team_EdictIsValid(int edict)
 {
 	return GetEntProp(edict, Prop_Send, "m_iTeamNum");
 }
@@ -225,23 +225,23 @@ stock Team_EdictIsValid(edict)
  * @param index			Team Index.
  * @return				Team edict or -1 if not found
  */
-stock Team_GetEdict(index)
+stock int Team_GetEdict(int index)
 {
-	static teams[MAX_TEAMS] = { INVALID_ENT_REFERENCE, ... };
+	static int teams[MAX_TEAMS] = { INVALID_ENT_REFERENCE, ... };
 
 	if (index < 0 || index > MAX_TEAMS) {
 		return -1;
 	}
 
-	new edict = teams[index];
+	int edict = teams[index];
 	if (Entity_IsValid(edict)) {
 		return edict;
 	}
 
-	new bool:foundTeamManager = false;
+	bool foundTeamManager = false;
 
-	new maxEntities = GetMaxEntities();
-	for (new entity=MaxClients+1; entity < maxEntities; entity++) {
+	int maxEntities = GetMaxEntities();
+	for (int entity=MaxClients+1; entity < maxEntities; entity++) {
 
 		if (!IsValidEntity(entity)) {
 			continue;
@@ -258,7 +258,7 @@ stock Team_GetEdict(index)
 			continue;
 		}
 
-		new num = Team_EdictGetNum(entity);
+		int num = Team_EdictGetNum(entity);
 
 		if (num >= 0 && num <= MAX_TEAMS) {
 			teams[num] = EntIndexToEntRef(entity);
@@ -280,10 +280,10 @@ stock Team_GetEdict(index)
  * @param index			Team Index.
  * @return				Client Index or -1 if no client was found in the specified team.
  */
-stock Team_GetAnyClient(index)
+stock int Team_GetAnyClient(int index)
 {
-	static client_cache[MAX_TEAMS] = -1;
-	new client;
+	static int client_cache[MAX_TEAMS] = -1;
+	int client;
 
 	if (index > 0) {
 		client = client_cache[index];

--- a/scripting/include/smlib/vehicles.inc
+++ b/scripting/include/smlib/vehicles.inc
@@ -15,9 +15,9 @@
  * @param vehicle			Entity index.
  * @return					Client index, or -1 if there is no driver.
  */
-stock Vehicle_GetDriver(vehicle)
+stock int Vehicle_GetDriver(int vehicle)
 {
-	new m_hVehicle = GetEntPropEnt(vehicle, Prop_Send, "m_hPlayer");
+	int m_hVehicle = GetEntPropEnt(vehicle, Prop_Send, "m_hPlayer");
 
 	return m_hVehicle;
 }
@@ -28,7 +28,7 @@ stock Vehicle_GetDriver(vehicle)
  * @param vehicle			Entity index.
  * @return					True if the vehicle has a driver, false otherwise
  */
-stock bool:Vehicle_HasDriver(vehicle)
+stock bool Vehicle_HasDriver(int vehicle)
 {
 	return !(Vehicle_GetDriver(vehicle) == -1);
 }
@@ -39,7 +39,7 @@ stock bool:Vehicle_HasDriver(vehicle)
  * @param vehicle			Entity index.
  * @return					True on success, false otherwise.
  */
-stock bool:Vehicle_ExitDriver(vehicle)
+stock bool Vehicle_ExitDriver(int vehicle)
 {
 	if (!Vehicle_HasDriver(vehicle)) {
 		return false;
@@ -54,7 +54,7 @@ stock bool:Vehicle_ExitDriver(vehicle)
  * @param vehicle			Entity index.
  * @return					True on success, false otherwise.
  */
-stock bool:Vehicle_TurnOn(vehicle)
+stock bool Vehicle_TurnOn(int vehicle)
 {
 
 	return AcceptEntityInput(vehicle, "TurnOn");
@@ -66,7 +66,7 @@ stock bool:Vehicle_TurnOn(vehicle)
  * @param vehicle			Entity index.
  * @return					True on success, false otherwise.
  */
-stock bool:Vehicle_TurnOff(vehicle)
+stock bool Vehicle_TurnOff(int vehicle)
 {
 
 	return AcceptEntityInput(vehicle, "TurnOff");
@@ -78,7 +78,7 @@ stock bool:Vehicle_TurnOff(vehicle)
  * @param vehicle			Entity index.
  * @return					True on success, false otherwise.
  */
-stock bool:Vehicle_Lock(vehicle)
+stock bool Vehicle_Lock(int vehicle)
 {
 
 	return AcceptEntityInput(vehicle, "Lock");
@@ -90,7 +90,7 @@ stock bool:Vehicle_Lock(vehicle)
  * @param vehicle			Entity index.
  * @return					True on success, false otherwise.
  */
-stock bool:Vehicle_Unlock(vehicle)
+stock bool Vehicle_Unlock(int vehicle)
 {
 
 	return AcceptEntityInput(vehicle, "Unlock");
@@ -102,7 +102,7 @@ stock bool:Vehicle_Unlock(vehicle)
  * @param vehicle			Entity index.
  * @return					True if it is a valid vehicle, false otherwise.
  */
-stock bool:Vehicle_IsValid(vehicle)
+stock bool Vehicle_IsValid(int vehicle)
 {
 	if (!Entity_IsValid(vehicle)) {
 		return false;
@@ -121,7 +121,7 @@ stock bool:Vehicle_IsValid(vehicle)
  * @param size				String Buffer size.
  * @noreturn
  */
-stock bool:Vehicle_GetScript(vehicle, String:buffer[], size)
+stock bool Vehicle_GetScript(int vehicle, char[] buffer, int size)
 {
 	GetEntPropString(vehicle, Prop_Data, "m_vehicleScript", buffer, size);
 }
@@ -135,7 +135,7 @@ stock bool:Vehicle_GetScript(vehicle, String:buffer[], size)
  * @param buffer			Vehicle Script path.
  * @noreturn
  */
-stock bool:Vehicle_SetScript(vehicle, String:script[])
+stock bool Vehicle_SetScript(int vehicle, char[] script)
 {
 	DispatchKeyValue(vehicle, "vehiclescript", script);
 }

--- a/scripting/include/smlib/weapons.inc
+++ b/scripting/include/smlib/weapons.inc
@@ -25,7 +25,7 @@
  * @param weapon		Weapon Entity.
  * @return				Owner of the weapon or INVALID_ENT_REFERENCE if the weapon has no owner.
  */
-stock Weapon_GetOwner(weapon)
+stock int Weapon_GetOwner(int weapon)
 {
 	return GetEntPropEnt(weapon, Prop_Data, "m_hOwner");
 }
@@ -37,7 +37,7 @@ stock Weapon_GetOwner(weapon)
  * @param entity		Entity Index.
  * @noreturn
  */
-stock Weapon_SetOwner(weapon, entity)
+stock void Weapon_SetOwner(int weapon, int entity)
 {
 	SetEntPropEnt(weapon, Prop_Data, "m_hOwner", entity);
 }
@@ -48,7 +48,7 @@ stock Weapon_SetOwner(weapon, entity)
  * @param weapon		Weapon Entity.
  * @return				True if the entity is a valid weapon, false otherwise.
  */
-stock Weapon_IsValid(weapon)
+stock bool Weapon_IsValid(int weapon)
 {
 	if (!IsValidEdict(weapon)) {
 		return false;
@@ -65,9 +65,9 @@ stock Weapon_IsValid(weapon)
  * @param absAngles		Absolute Angles Vector.
  * @return				Weapon Index of the created weapon or INVALID_ENT_REFERENCE on error.
  */
-stock Weapon_Create(const String:className[], Float:absOrigin[3], Float:absAngles[3])
+stock int Weapon_Create(const char[] className, float absOrigin[3], float absAngles[3])
 {
-	new weapon = Entity_Create(className);
+	int weapon = Entity_Create(className);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return INVALID_ENT_REFERENCE;
@@ -89,13 +89,13 @@ stock Weapon_Create(const String:className[], Float:absOrigin[3], Float:absAngle
  * @param absAngles		Absolute Angles Vector.
  * @return				Weapon Index of the created weapon or INVALID_ENT_REFERENCE on error.
  */
-stock Weapon_CreateForOwner(client, const String:className[])
+stock int Weapon_CreateForOwner(int client, const char[] className)
 {
-	decl Float:absOrigin[3], Float:absAngles[3];
+	float absOrigin[3], absAngles[3];
 	Entity_GetAbsOrigin(client, absOrigin);
 	Entity_GetAbsAngles(client, absAngles);
 
-	new weapon = Weapon_Create(className, absOrigin, absAngles);
+	int weapon = Weapon_Create(className, absOrigin, absAngles);
 
 	if (weapon == INVALID_ENT_REFERENCE) {
 		return INVALID_ENT_REFERENCE;
@@ -113,7 +113,7 @@ stock Weapon_CreateForOwner(client, const String:className[])
  * @param weapon		Weapon Entity.
  * @return				Subtype of the weapon.
  */
-stock Weapon_GetSubType(weapon)
+stock int Weapon_GetSubType(int weapon, int value)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iSubType");
 }
@@ -124,9 +124,9 @@ stock Weapon_GetSubType(weapon)
  * @param weapon		Weapon Entity.
  * @return				True if weapon is currently reloading, false if not.
  */
-stock bool:Weapon_IsReloading(weapon)
+stock bool Weapon_IsReloading(int weapon)
 {
-	return bool:GetEntProp(weapon, Prop_Data, "m_bInReload");
+	return view_as<bool>(GetEntProp(weapon, Prop_Data, "m_bInReload"));
 }
 
 /*
@@ -145,7 +145,7 @@ stock bool:Weapon_IsReloading(weapon)
  * @param weapon		Weapon Entity.
  * @return				Weapon State.
  */
-stock Weapon_GetState(weapon)
+stock int Weapon_GetState(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iState");
 }
@@ -156,9 +156,9 @@ stock Weapon_GetState(weapon)
  * @param weapon		Weapon Entity.
  * @return				True or False.
  */
-stock bool:Weapon_FiresUnderWater(weapon)
+stock bool Weapon_FiresUnderWater(int weapon)
 {
-	return bool:GetEntProp(weapon, Prop_Data, "m_bFiresUnderwater");
+	return view_as<bool>(GetEntProp(weapon, Prop_Data, "m_bFiresUnderwater"));
 }
 
 /*
@@ -168,9 +168,9 @@ stock bool:Weapon_FiresUnderWater(weapon)
  * @param can			True or False.
  * @noreturn
  */
-stock Weapon_SetFiresUnderWater(weapon, bool:can=true)
+stock void Weapon_SetFiresUnderWater(int weapon, bool can=true)
 {
-	SetEntProp(weapon, Prop_Data, "m_bFiresUnderwater", _:can);
+	SetEntProp(weapon, Prop_Data, "m_bFiresUnderwater", view_as<int>(can));
 }
 
 /*
@@ -179,9 +179,9 @@ stock Weapon_SetFiresUnderWater(weapon, bool:can=true)
  * @param weapon		Weapon Entity.
  * @return				True or False.
  */
-stock bool:Weapon_FiresUnderWaterAlt(weapon)
+stock bool Weapon_FiresUnderWaterAlt(int weapon)
 {
-	return bool:GetEntProp(weapon, Prop_Data, "m_bAltFiresUnderwater");
+	return view_as<bool>(GetEntProp(weapon, Prop_Data, "m_bAltFiresUnderwater"));
 }
 
 /*
@@ -191,9 +191,9 @@ stock bool:Weapon_FiresUnderWaterAlt(weapon)
  * @param can			True or False.
  * @noreturn
  */
-stock Weapon_SetFiresUnderWaterAlt(weapon, bool:can=true)
+stock void Weapon_SetFiresUnderWaterAlt(int weapon, bool can=true)
 {
-	SetEntProp(weapon, Prop_Data, "m_bAltFiresUnderwater", _:can);
+	SetEntProp(weapon, Prop_Data, "m_bAltFiresUnderwater", view_as<int>(can));
 }
 
 /*
@@ -202,7 +202,7 @@ stock Weapon_SetFiresUnderWaterAlt(weapon, bool:can=true)
  * @param weapon		Weapon Entity.
  * @return				Primary ammo type value.
  */
-stock Weapon_GetPrimaryAmmoType(weapon)
+stock int Weapon_GetPrimaryAmmoType(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iPrimaryAmmoType");
 }
@@ -212,8 +212,9 @@ stock Weapon_GetPrimaryAmmoType(weapon)
  *
  * @param weapon		Weapon Entity.
  * @param type			Primary ammo type value.
+ * @noreturn
  */
-stock Weapon_SetPrimaryAmmoType(weapon,type)
+stock void Weapon_SetPrimaryAmmoType(int weapon, int type)
 {
 	SetEntProp(weapon, Prop_Data, "m_iPrimaryAmmoType", type);
 }
@@ -224,7 +225,7 @@ stock Weapon_SetPrimaryAmmoType(weapon,type)
  * @param weapon		Weapon Entity.
  * @return				Secondary ammo type value.
  */
-stock Weapon_GetSecondaryAmmoType(weapon)
+stock int Weapon_GetSecondaryAmmoType(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iSecondaryAmmoType");
 }
@@ -234,8 +235,9 @@ stock Weapon_GetSecondaryAmmoType(weapon)
  *
  * @param weapon		Weapon Entity.
  * @param type			Secondary ammo type value.
+ * @noreturn
  */
-stock Weapon_SetSecondaryAmmoType(weapon,type)
+stock void Weapon_SetSecondaryAmmoType(int weapon, int type)
 {
 	SetEntProp(weapon, Prop_Data, "m_iSecondaryAmmoType", type);
 }
@@ -246,7 +248,7 @@ stock Weapon_SetSecondaryAmmoType(weapon,type)
  * @param weapon		Weapon Entity.
  * @return				Primary Clip count.
  */
-stock Weapon_GetPrimaryClip(weapon)
+stock int Weapon_GetPrimaryClip(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iClip1");
 }
@@ -256,8 +258,9 @@ stock Weapon_GetPrimaryClip(weapon)
  *
  * @param weapon		Weapon Entity.
  * @param value			Clip Count value.
+ * @noreturn
  */
-stock Weapon_SetPrimaryClip(weapon, value)
+stock void Weapon_SetPrimaryClip(int weapon, int value)
 {
 	SetEntProp(weapon, Prop_Data, "m_iClip1", value);
 }
@@ -268,7 +271,7 @@ stock Weapon_SetPrimaryClip(weapon, value)
  * @param weapon		Weapon Entity.
  * @return				Secondy Clip count.
  */
-stock Weapon_GetSecondaryClip(weapon)
+stock int Weapon_GetSecondaryClip(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iClip2");
 }
@@ -278,8 +281,9 @@ stock Weapon_GetSecondaryClip(weapon)
  *
  * @param weapon		Weapon Entity.
  * @param value			Clip Count value.
+ * @noreturn
  */
-stock Weapon_SetSecondaryClip(weapon, value)
+stock void Weapon_SetSecondaryClip(int weapon, int value)
 {
 	SetEntProp(weapon, Prop_Data, "m_iClip2", value);
 }
@@ -290,8 +294,9 @@ stock Weapon_SetSecondaryClip(weapon, value)
  * @param weapon		Weapon Entity.
  * @param primary		Primary Clip Count value.
  * @param secondary		Primary Clip Count value.
+ * @noreturn
  */
-stock Weapon_SetClips(weapon, primary, secondary)
+stock void Weapon_SetClips(int weapon, int primary, int secondary)
 {
 	Weapon_SetPrimaryClip(weapon, primary);
 	Weapon_SetSecondaryClip(weapon, secondary);
@@ -306,7 +311,7 @@ stock Weapon_SetClips(weapon, primary, secondary)
  * @param weapon		Weapon Entity.
  * @return				Primary Ammo Count.
  */
-stock Weapon_GetPrimaryAmmoCount(weapon)
+stock int Weapon_GetPrimaryAmmoCount(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iPrimaryAmmoCount");
 }
@@ -321,7 +326,7 @@ stock Weapon_GetPrimaryAmmoCount(weapon)
  * @param value			Primary Ammo Count.
  * @noreturn
  */
-stock Weapon_SetPrimaryAmmoCount(weapon, value)
+stock void Weapon_SetPrimaryAmmoCount(int weapon, int value)
 {
 	SetEntProp(weapon, Prop_Data, "m_iPrimaryAmmoCount", value);
 }
@@ -335,7 +340,7 @@ stock Weapon_SetPrimaryAmmoCount(weapon, value)
  * @param weapon		Weapon Entity.
  * @return				Secondary Ammo Count.
  */
-stock Weapon_GetSecondaryAmmoCount(weapon)
+stock int Weapon_GetSecondaryAmmoCount(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_iSecondaryAmmoCount");
 }
@@ -350,7 +355,7 @@ stock Weapon_GetSecondaryAmmoCount(weapon)
  * @param value			Secondary Ammo Count.
  * @noreturn
  */
-stock Weapon_SetSecondaryAmmoCount(weapon, value)
+stock void Weapon_SetSecondaryAmmoCount(int weapon, int value)
 {
 	SetEntProp(weapon, Prop_Data, "m_iSecondaryAmmoCount", value);
 }
@@ -366,7 +371,7 @@ stock Weapon_SetSecondaryAmmoCount(weapon, value)
  * @value secondary		Secondary Ammo Count.
  * @noreturn
  */
-stock Weapon_SetAmmoCounts(weapon, primary, secondary)
+stock void Weapon_SetAmmoCounts(int weapon, int primary, int secondary)
 {
 	Weapon_SetPrimaryAmmoCount(weapon, primary);
 	Weapon_SetSecondaryAmmoCount(weapon, secondary);
@@ -378,7 +383,7 @@ stock Weapon_SetAmmoCounts(weapon, primary, secondary)
  * @param weapon		Weapon Entity.
  * @return				View Model Index.
  */
-stock Weapon_GetViewModelIndex(weapon)
+stock int Weapon_GetViewModelIndex(int weapon)
 {
 	return GetEntProp(weapon, Prop_Data, "m_nViewModelIndex");
 }
@@ -391,7 +396,7 @@ stock Weapon_GetViewModelIndex(weapon)
  * @param index			Model Index.
  * @noreturn
  */
-stock Weapon_SetViewModelIndex(weapon, index)
+stock void Weapon_SetViewModelIndex(int weapon, int index)
 {
 	SetEntProp(weapon, Prop_Data, "m_nViewModelIndex", index);
 	ChangeEdictState(weapon, FindDataMapInfo(weapon, "m_nViewModelIndex"));

--- a/scripting/include/smlib/world.inc
+++ b/scripting/include/smlib/world.inc
@@ -11,7 +11,7 @@
  * @param vec		Vector buffer
  * @noreturn
  */
-stock World_GetMaxs(Float:vec[3]) {
+stock void World_GetMaxs(float vec[3]) {
 
 	GetEntPropVector(0, Prop_Data, "m_WorldMaxs", vec);
 }

--- a/scripting/tests/test_colors.sp
+++ b/scripting/tests/test_colors.sp
@@ -1,6 +1,8 @@
 
 // enforce semicolons after each code statement
 #pragma semicolon 1
+// enforce transitional syntax
+#pragma newdecls required
 
 #include <sourcemod>
 #include <sdktools>
@@ -18,7 +20,7 @@
 
 *****************************************************************/
 
-public Plugin:myinfo = {
+public Plugin myinfo = {
 	name = "smlib - color tests",
 	author = "Berni",
 	description = "",
@@ -50,13 +52,13 @@ public Plugin:myinfo = {
 
 *****************************************************************/
 
-public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
     MarkNativeAsOptional("GetUserMessageType");
     return APLRes_Success;
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	Client_PrintToChatAll(false, "Loading plugin test-colors compiled on %s %s", __DATE__, __TIME__);
 	RegAdminCmd("sm_testcolors", Command_TestColors, ADMFLAG_ROOT);
@@ -72,9 +74,9 @@ public OnPluginStart()
 
 ****************************************************************/
 
-public Action:Command_TestColors(client, args)
+public Action Command_TestColors(int client, int args)
 {
-	decl String:arguments[255];
+	char arguments[255];
 
 	GetCmdArgString(arguments, sizeof(arguments));
 	Client_PrintToChat(client, true, "%s", arguments);

--- a/scripting/tests/test_compile-all.sp
+++ b/scripting/tests/test_compile-all.sp
@@ -13,6 +13,8 @@
 
 // enforce semicolons after each code statement
 #pragma semicolon 1
+// enforce transitional syntax
+#pragma newdecls required
 
 #include <sourcemod>
 #include <smlib>
@@ -29,7 +31,7 @@
 
 *****************************************************************/
 
-public Plugin:myinfo = {
+public Plugin myinfo = {
 	name = "smlib Testing Suite",
 	author = "Berni, Chanz",
 	description = "Plugin by Berni",
@@ -61,13 +63,14 @@ public Plugin:myinfo = {
 
 *****************************************************************/
 
-public OnPluginStart() {
+public void OnPluginStart() {
 
-	new arr[1], String:arr_str[1][1], arr_4[4];
-	decl Float:vec[3];
-	decl String:buf[1], String:buf_10[10], String:twoDimStrArr[1][1];
-	new variable;
-	new Handle:handle;
+	int arr[1], arr_4[4];
+	char arr_str[1][1];
+	float vec[3];
+	char buf[1], buf_10[10], twoDimStrArr[1][1];
+	int variable;
+	Handle handle;
 
 	// File: arrays.inc
 	Array_FindValue(arr, sizeof(arr), 1);
@@ -85,9 +88,9 @@ public OnPluginStart() {
 	Client_FindBySteamId("");
 	Client_FindByName("");
 	Client_GetObserverMode(0);
-	Client_SetObserverMode(0, Obs_Mode:0);
+	Client_SetObserverMode(0, view_as<Obs_Mode>(0));
 	Client_GetObserverLastMode(0);
-	Client_SetObserverLastMode(0, Obs_Mode:0);
+	Client_SetObserverLastMode(0, view_as<Obs_Mode>(0));
 	Client_GetViewOffset(0, vec);
 	Client_SetViewOffset(0, vec);
 	Client_GetObserverTarget(0);
@@ -185,7 +188,7 @@ public OnPluginStart() {
 	Client_UnMute(0);
 	Client_IsMuted(0);
 	Client_PrintToConsole(0, "");
-	Client_Print(0, ClientHudPrint:0, "");
+	Client_Print(0, view_as<ClientHudPrint>(0), "");
 	Client_PrintToChatExclude(0);
 	Client_Reply(0, "");
 	Client_MatchesFilter(0, 0);
@@ -221,9 +224,9 @@ public OnPluginStart() {
 	ConCommand_RemoveFlags("", 0);
 
 	// File: convars.inc
-	Convar_HasFlags(INVALID_HANDLE, 0);
-	Convar_AddFlags(INVALID_HANDLE, 0);
-	Convar_RemoveFlags(INVALID_HANDLE, 0);
+	Convar_HasFlags(null, 0);
+	Convar_AddFlags(null, 0);
+	Convar_RemoveFlags(null, 0);
 	Convar_IsValidName("");
 
 	// File: crypt.inc
@@ -239,7 +242,7 @@ public OnPluginStart() {
 	Debug_FloatArray(vec);
 
 	// File: dynarrays.inc
-	DynArray_GetBool(INVALID_HANDLE, 0);
+	DynArray_GetBool(null, 0);
 
 	// File: edicts.inc
 	Edict_FindByName("");
@@ -296,10 +299,10 @@ public OnPluginStart() {
 	Entity_ClearSpawnFlags(0);
 	Entity_HasSpawnFlags(0, 0);
 	Entity_GetEFlags(0);
-	Entity_SetEFlags(0, Entity_Flags:0);
-	Entity_AddEFlags(0, Entity_Flags:0);
-	Entity_RemoveEFlags(0, Entity_Flags:0);
-	Entity_HasEFlags(0, Entity_Flags:0);
+	Entity_SetEFlags(0, view_as<Entity_Flags>(0));
+	Entity_AddEFlags(0, view_as<Entity_Flags>(0));
+	Entity_RemoveEFlags(0, view_as<Entity_Flags>(0));
+	Entity_HasEFlags(0, view_as<Entity_Flags>(0));
 	Entity_MarkSurrBoundsDirty(0);
 	Entity_GetFlags(0);
 	Entity_SetFlags(0, 0);
@@ -308,13 +311,13 @@ public OnPluginStart() {
 	Entity_ToggleFlag(0, 0);
 	Entity_ClearFlags(0);
 	Entity_GetSolidFlags(0);
-	Entity_SetSolidFlags(0, SolidFlags_t:0);
-	Entity_AddSolidFlags(0, SolidFlags_t:0);
-	Entity_RemoveSolidFlags(0, SolidFlags_t:0);
+	Entity_SetSolidFlags(0, view_as<SolidFlags_t>(0));
+	Entity_AddSolidFlags(0, view_as<SolidFlags_t>(0));
+	Entity_RemoveSolidFlags(0, view_as<SolidFlags_t>(0));
 	Entity_ClearSolidFlags(0);
-	Entity_SolidFlagsSet(0, SolidFlags_t:0);
+	Entity_SolidFlagsSet(0, view_as<SolidFlags_t>(0));
 	Entity_GetSolidType(0);
-	Entity_SetSolidType(0, SolidType_t:0);
+	Entity_SetSolidType(0, view_as<SolidType_t>(0));
 	Entity_IsSolid(0);
 	Entity_GetModel(0, buf, sizeof(buf));
 	Entity_SetModel(0, "");
@@ -322,7 +325,7 @@ public OnPluginStart() {
 	Entity_SetModelIndex(0, 0);
 	Entity_SetMaxSpeed(0, 0.0);
 	Entity_GetCollisionGroup(0);
-	Entity_SetCollisionGroup(0, Collision_Group_t:0);
+	Entity_SetCollisionGroup(0, view_as<Collision_Group_t>(0));
 	Entity_GetAbsOrigin(0, vec);
 	Entity_SetAbsOrigin(0, vec);
 	Entity_GetAbsAngles(0, vec);
@@ -434,8 +437,8 @@ public OnPluginStart() {
 	Math_Overflow(0, 0, 0);
 
 	// File: menus.inc
-	Menu_AddIntItem(INVALID_HANDLE, 0, "");
-	Menu_GetIntItem(INVALID_HANDLE, 0);
+	Menu_AddIntItem(null, 0, "");
+	Menu_GetIntItem(null, 0);
 
 	// File: server.inc
 	Server_GetIP();
@@ -444,11 +447,11 @@ public OnPluginStart() {
 	Server_GetHostName(buf, sizeof(buf));
 
 	// File: sql.inc
-	SQL_TQueryF(INVALID_HANDLE, INVALID_FUNCTION, 0, DBPrio_Normal, "");
-	SQL_FetchIntByName(INVALID_HANDLE, "");
-	SQL_FetchBoolByName(INVALID_HANDLE, "");
-	SQL_FetchFloatByName(INVALID_HANDLE, "");
-	SQL_FetchStringByName(INVALID_HANDLE, "", buf, sizeof(buf));
+	SQL_TQueryF(null, INVALID_FUNCTION, 0, DBPrio_Normal, "");
+	SQL_FetchIntByName(null, "");
+	SQL_FetchBoolByName(null, "");
+	SQL_FetchFloatByName(null, "");
+	SQL_FetchStringByName(null, "", buf, sizeof(buf));
 
 	// File: strings.inc
 	String_IsNumeric("");

--- a/scripting/tests/test_compile-all.sp
+++ b/scripting/tests/test_compile-all.sp
@@ -362,7 +362,7 @@ public void OnPluginStart() {
 	Entity_GetGroundEntity(0);
 	Entity_Hurt(0, 0);
 	Entity_GetParent(0);
-	Entity_ClearParent(0);
+//	Entity_ClearParent(0);
 	Entity_SetParent(0, 0);
 	Entity_ChangeOverTime(0, 0.1, INVALID_FUNCTION);
 	Entity_GetNextChild(0);
@@ -495,7 +495,7 @@ public void OnPluginStart() {
 	Weapon_IsValid(0);
 	Weapon_Create("", vec, vec);
 	Weapon_CreateForOwner(0, "");
-	Weapon_GetSubType(0);
+	Weapon_GetSubType(0, 0);
 	Weapon_IsReloading(0);
 	Weapon_GetState(0);
 	Weapon_FiresUnderWater(0);

--- a/scripting/tests/test_compile-all.sp
+++ b/scripting/tests/test_compile-all.sp
@@ -362,7 +362,7 @@ public void OnPluginStart() {
 	Entity_GetGroundEntity(0);
 	Entity_Hurt(0, 0);
 	Entity_GetParent(0);
-//	Entity_ClearParent(0);
+	Entity_ClearParent(0);
 	Entity_SetParent(0, 0);
 	Entity_ChangeOverTime(0, 0.1, INVALID_FUNCTION);
 	Entity_GetNextChild(0);


### PR DESCRIPTION
This PR has all valid changes up till this point, except for methodmaps surrounding user messages. All changes should be compatible up to SM-1.10-dev.

Added:
- Transitional Syntax through 1.10.
- Fixed return types on some functions.
- Include some corrections to documentation based on return types.
- Fix invalid prototypes.

Does not include:
- Methodmaps surrounding UserMessages (`Protobuf` and `BfWrite`). A possible method of doing this has been included with `Client_ScreenFade`, although I'm not quite sure it is correct (it may leak a handle as well).

Before merging:
- A new branch would not be a bad idea.
- Feedback on methodmap is needed (see `Does not include`).