### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: c
 
 env:
-    - SMVERSION=1.7
-    - SMVERSION=1.8
     - SMVERSION=1.9
+    - SMVERSION=1.10
 
 matrix:
     fast_finish: true
     allow_failures:
-        - env: SMVERSION=1.7
+        - env: SMVERSION=1.10
 
 before_install:
     - sudo apt-get update


### PR DESCRIPTION
I removed SM1.7 and SM1.8, since this are the "old-stable" versions. Instead of supporting old version we should test smlib with the current stable version (1.9) of SourceMod. I also added SourceMod 1.10, but we allow failures here because SourceMod 1.10 is the current dev-Version.