### PR TITLE
Fix enum struct and update formatting

### DIFF
--- a/scripting/include/smlib/colors.inc
+++ b/scripting/include/smlib/colors.inc
@@ -12,22 +12,22 @@
 
 enum ChatColorSubjectType
 {
-	ChatColorSubjectType_none		= -3,
+	ChatColorSubjectType_none       = -3,
 
 	// Subject/Team colors
-	ChatColorSubjectType_player		= -2,
+	ChatColorSubjectType_player     = -2,
 	ChatColorSubjectType_undefined	= -1,
-	ChatColorSubjectType_world		= 0
+	ChatColorSubjectType_world      = 0
 	// Anything higher is a specific team
 }
 
-enum ChatColorInfo
+enum struct ChatColorInfo
 {
-	ChatColorInfo_Code,
-	ChatColorInfo_Alternative,
-	bool:ChatColorInfo_Supported,
-	ChatColorSubjectType:ChatColorInfo_SubjectType
-};
+	int ChatColorInfo_Code;
+	int ChatColorInfo_Alternative;
+	bool ChatColorInfo_Supported;
+	ChatColorSubjectType ChatColorInfo_SubjectType;
+}
 
 enum ChatColor
 {
@@ -42,60 +42,46 @@ enum ChatColor
 	ChatColor_Gray,
 	ChatColor_Green,
 	ChatColor_Olivegreen,
-	ChatColor_Black
+	ChatColor_Black,
+	ChatColor_MAXCOLORS
 }
 
 static char chatColorTags[][] = {
-	"N",	// Normal
-	"O",	// Orange
-	"R",	// Red
-	"RB",	// Red, Blue
-	"B",	// Blue
-	"BR",	// Blue, Red
-	"T",	// Team
-	"L",	// Light green
-	"GRA",	// GRAy
-	"G",	// Green
-	"OG",	// Olive green
-	"BLA"	// BLAck
+	"N",    // Normal
+	"O",    // Orange
+	"R",    // Red
+	"RB",   // Red, Blue
+	"B",    // Blue
+	"BR",   // Blue, Red
+	"T",    // Team
+	"L",    // Light green
+	"GRA",  // Gray
+	"G",    // Green
+	"OG",   // Olive green
+	"BLA"   // Black
 };
 
 static char chatColorNames[][] = {
-	"normal",		// Normal
-	"orange",		// Orange
-	"red",			// Red
-	"redblue",		// Red, Blue
-	"blue",			// Blue
-	"bluered",		// Blue, Red
-	"team",			// Team
-	"lightgreen",	// Light green
-	"gray",			// GRAy
-	"green",		// Green
-	"olivegreen",	// Olive green
-	"black"			// BLAck
+	"normal",               // Normal
+	"orange",               // Orange
+	"red",                  // Red
+	"redblue",              // Red, Blue
+	"blue",                 // Blue
+	"bluered",              // Blue, Red
+	"team",                 // Team
+	"lightgreen",           // Light green
+	"gray",                 // Gray
+	"green",                // Green
+	"olivegreen",           // Olive green
+	"black"                 // Black
 };
 
-static int chatColorInfo[][ChatColorInfo] =
-{
-	// Code , alternative	, Is Supported?	Chat color subject type 				Color name
-	{ '\x01', -1/* None	 */	, true,			ChatColorSubjectType_none,			},	// Normal
-	{ '\x01', 0	/* None	 */	, true,			ChatColorSubjectType_none,			},	// Orange
-	{ '\x03', 9	/* Green */	, true,			view_as<ChatColorSubjectType>(2)	},	// Red
-	{ '\x03', 4	/* Blue	 */	, true,			view_as<ChatColorSubjectType>(2)	},	// Red, Blue
-	{ '\x03', 9	/* Green */	, true,			view_as<ChatColorSubjectType>(3)	},	// Blue
-	{ '\x03', 2	/* Red	 */	, true,			view_as<ChatColorSubjectType>(3)	},	// Blue, Red
-	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType_player			},	// Team
-	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType_world			},	// Light green
-	{ '\x03', 9	/* Green */	, true,			ChatColorSubjectType_undefined		},	// GRAy
-	{ '\x04', 0	/* Normal*/	, true,			ChatColorSubjectType_none			},	// Green
-	{ '\x05', 9	/* Green */	, true,			ChatColorSubjectType_none			},	// Olive green
-	{ '\x06', 9	/* Green */	, true,			ChatColorSubjectType_none			}	// BLAck
-};
+static ChatColorInfo chatColorInfo[ChatColor_MAXCOLORS];
 
-static bool checkTeamPlay			= false;
-static ConVar mp_teamplay			= null;
+static bool checkTeamPlay               = false;
+static ConVar mp_teamplay               = null;
 static bool isSayText2_supported	= true;
-static int chatSubject				= CHATCOLOR_NOSUBJECT;
+static int chatSubject                  = CHATCOLOR_NOSUBJECT;
 
 /**
  * Sets the subject (a client) for the chat color parser.
@@ -133,10 +119,10 @@ stock void Color_ChatClearSubject()
  * table. The support colors are hardcoded, but can be overriden for each game by
  * creating the file gamedata/smlib_colors.games.txt.
  *
- * @param str				Chat String
- * @param subject			Output Buffer
- * @param size				Output Buffer size
- * @return					Returns a value for the subject
+ * @param str                           Chat String
+ * @param subject                       Output Buffer
+ * @param size                          Output Buffer size
+ * @return                              Returns a value for the subject
  */
 stock int Color_ParseChatText(const char[] str, char[] buffer, int size)
 {
@@ -288,7 +274,7 @@ stock void Color_TagToCode(const char[] tag, int &subject=-1, char result[10])
 		// Check if the color is actually supported 'n stuff.
 		Color_GetChatColorInfo(n, subject);
 
-		result[0] = chatColorInfo[n][ChatColorInfo_Code];
+		result[0] = chatColorInfo[n].ChatColorInfo_Code;
 		result[1] = '\0';
 	}
 
@@ -339,50 +325,122 @@ static stock void Color_ChatInitialize()
 	}
 
 	initialized = true;
+	
+	// Normal
+	chatColorInfo[ChatColor_Normal].ChatColorInfo_Code = '\x01';
+	chatColorInfo[ChatColor_Normal].ChatColorInfo_Alternative = -1; /* None */
+	chatColorInfo[ChatColor_Normal].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Normal].ChatColorInfo_SubjectType = ChatColorSubjectType_none;
+	
+	// Orange
+	chatColorInfo[ChatColor_Orange].ChatColorInfo_Code = '\x01';
+	chatColorInfo[ChatColor_Orange].ChatColorInfo_Alternative = 0; /* None */
+	chatColorInfo[ChatColor_Orange].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Orange].ChatColorInfo_SubjectType = ChatColorSubjectType_none;
+	
+	// Red
+	chatColorInfo[ChatColor_Red].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_Red].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Red].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Red].ChatColorInfo_SubjectType = view_as<ChatColorSubjectType>(2);
+	
+	// Red, Blue
+	chatColorInfo[ChatColor_RedBlue].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_RedBlue].ChatColorInfo_Alternative = 4; /* Blue */
+	chatColorInfo[ChatColor_RedBlue].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_RedBlue].ChatColorInfo_SubjectType = view_as<ChatColorSubjectType>(2);
+	
+	// Blue
+	chatColorInfo[ChatColor_Blue].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_Blue].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Blue].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Blue].ChatColorInfo_SubjectType = view_as<ChatColorSubjectType>(3);
+	
+	// Blue, Red
+	chatColorInfo[ChatColor_BlueRed].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_BlueRed].ChatColorInfo_Alternative = 2; /* Red */
+	chatColorInfo[ChatColor_BlueRed].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_BlueRed].ChatColorInfo_SubjectType = view_as<ChatColorSubjectType>(3);
+	
+	// Team
+	chatColorInfo[ChatColor_Team].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_Team].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Team].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Team].ChatColorInfo_SubjectType = ChatColorSubjectType_player;
+	
+	// Light green
+	chatColorInfo[ChatColor_Lightgreen].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_Lightgreen].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Lightgreen].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Lightgreen].ChatColorInfo_SubjectType = ChatColorSubjectType_world;
+
+	// Gray
+	chatColorInfo[ChatColor_Gray].ChatColorInfo_Code = '\x03';
+	chatColorInfo[ChatColor_Gray].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Gray].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Gray].ChatColorInfo_SubjectType = ChatColorSubjectType_undefined;
+
+	// Green
+	chatColorInfo[ChatColor_Green].ChatColorInfo_Code = '\x04';
+	chatColorInfo[ChatColor_Green].ChatColorInfo_Alternative = 0; /* Normal*/
+	chatColorInfo[ChatColor_Green].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Green].ChatColorInfo_SubjectType = ChatColorSubjectType_none;
+
+	// Olive green
+	chatColorInfo[ChatColor_Olivegreen].ChatColorInfo_Code = '\x05';
+	chatColorInfo[ChatColor_Olivegreen].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Olivegreen].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Olivegreen].ChatColorInfo_SubjectType = ChatColorSubjectType_none;
+
+	// Black
+	chatColorInfo[ChatColor_Black].ChatColorInfo_Code = '\x06';
+	chatColorInfo[ChatColor_Black].ChatColorInfo_Alternative = 9; /* Green */
+	chatColorInfo[ChatColor_Black].ChatColorInfo_Supported = true;
+	chatColorInfo[ChatColor_Black].ChatColorInfo_SubjectType = ChatColorSubjectType_none;
 
 	char gameFolderName[PLATFORM_MAX_PATH];
 	GetGameFolderName(gameFolderName, sizeof(gameFolderName));
 
-	chatColorInfo[ChatColor_Black][ChatColorInfo_Supported]		    = false;
+	chatColorInfo[ChatColor_Black].ChatColorInfo_Supported          = false;
 
 	if (strncmp(gameFolderName, "left4dead", 9, false) != 0 &&
 		!StrEqual(gameFolderName, "cstrike", false) &&
 		!StrEqual(gameFolderName, "tf", false))
 	{
-		chatColorInfo[ChatColor_Lightgreen][ChatColorInfo_Supported]= false;
-		chatColorInfo[ChatColor_Gray][ChatColorInfo_Supported]		= false;
+		chatColorInfo[ChatColor_Lightgreen].ChatColorInfo_Supported = false;
+		chatColorInfo[ChatColor_Gray].ChatColorInfo_Supported       = false;
 	}
 
 	if (StrEqual(gameFolderName, "tf", false)) {
-		chatColorInfo[ChatColor_Black][ChatColorInfo_Supported]		= true;
+		chatColorInfo[ChatColor_Black].ChatColorInfo_Supported      = true;
 
-		chatColorInfo[ChatColor_Gray][ChatColorInfo_Code]			= '\x01';
-		chatColorInfo[ChatColor_Gray][ChatColorInfo_SubjectType]	= ChatColorSubjectType_none;
+		chatColorInfo[ChatColor_Gray].ChatColorInfo_Code            = '\x01';
+		chatColorInfo[ChatColor_Gray].ChatColorInfo_SubjectType     = ChatColorSubjectType_none;
 	}
 	else if (strncmp(gameFolderName, "left4dead", 9, false) == 0) {
-		chatColorInfo[ChatColor_Red][ChatColorInfo_SubjectType]		= view_as<ChatColorSubjectType>(3);
-		chatColorInfo[ChatColor_RedBlue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(3);
-		chatColorInfo[ChatColor_Blue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
-		chatColorInfo[ChatColor_BlueRed][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
+		chatColorInfo[ChatColor_Red].ChatColorInfo_SubjectType      = view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_RedBlue].ChatColorInfo_SubjectType  = view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_Blue].ChatColorInfo_SubjectType     = view_as<ChatColorSubjectType>(2);
+		chatColorInfo[ChatColor_BlueRed].ChatColorInfo_SubjectType  = view_as<ChatColorSubjectType>(2);
 
-		chatColorInfo[ChatColor_Orange][ChatColorInfo_Code]			= '\x04';
-		chatColorInfo[ChatColor_Green][ChatColorInfo_Code]			= '\x05';
+		chatColorInfo[ChatColor_Orange].ChatColorInfo_Code          = '\x04';
+		chatColorInfo[ChatColor_Green].ChatColorInfo_Code           = '\x05';
 	}
 	else if (StrEqual(gameFolderName, "hl2mp", false)) {
-		chatColorInfo[ChatColor_Red][ChatColorInfo_SubjectType]		= view_as<ChatColorSubjectType>(3);
-		chatColorInfo[ChatColor_RedBlue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(3);
-		chatColorInfo[ChatColor_Blue][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
-		chatColorInfo[ChatColor_BlueRed][ChatColorInfo_SubjectType]	= view_as<ChatColorSubjectType>(2);
-		chatColorInfo[ChatColor_Black][ChatColorInfo_Supported]		= true;
+		chatColorInfo[ChatColor_Red].ChatColorInfo_SubjectType      = view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_RedBlue].ChatColorInfo_SubjectType  = view_as<ChatColorSubjectType>(3);
+		chatColorInfo[ChatColor_Blue].ChatColorInfo_SubjectType     = view_as<ChatColorSubjectType>(2);
+		chatColorInfo[ChatColor_BlueRed].ChatColorInfo_SubjectType  = view_as<ChatColorSubjectType>(2);
+		chatColorInfo[ChatColor_Black].ChatColorInfo_Supported      = true;
 
 		checkTeamPlay												= true;
 	}
 	else if (StrEqual(gameFolderName, "dod", false)) {
-		chatColorInfo[ChatColor_Gray][ChatColorInfo_Code]			= '\x01';
-		chatColorInfo[ChatColor_Gray][ChatColorInfo_SubjectType]	= ChatColorSubjectType_none;
+		chatColorInfo[ChatColor_Gray].ChatColorInfo_Code            = '\x01';
+		chatColorInfo[ChatColor_Gray].ChatColorInfo_SubjectType     = ChatColorSubjectType_none;
 
-		chatColorInfo[ChatColor_Black][ChatColorInfo_Supported]		= true;
-		chatColorInfo[ChatColor_Orange][ChatColorInfo_Supported]	= false;
+		chatColorInfo[ChatColor_Black].ChatColorInfo_Supported      = true;
+		chatColorInfo[ChatColor_Orange].ChatColorInfo_Supported     = false;
 	}
 
 	if (GetUserMessageId("SayText2") == INVALID_MESSAGE_ID) {
@@ -403,22 +461,22 @@ static stock void Color_ChatInitialize()
 
 				Format(keyName, sizeof(keyName), "%s_code",			chatColorNames[i]);
 				if (GameConfGetKeyValue(gamedata, keyName, buffer, sizeof(buffer))) {
-					chatColorInfo[i][ChatColorInfo_Code]			= StringToInt(buffer);
+					chatColorInfo[i].ChatColorInfo_Code             = StringToInt(buffer);
 				}
 
 				Format(keyName, sizeof(keyName), "%s_alternative",	chatColorNames[i]);
 				if (GameConfGetKeyValue(gamedata, keyName, buffer, sizeof(buffer))) {
-					chatColorInfo[i][ChatColorInfo_Alternative]		= buffer[0];
+					chatColorInfo[i].ChatColorInfo_Alternative      = buffer[0];
 				}
 
 				Format(keyName, sizeof(keyName), "%s_supported",	chatColorNames[i]);
 				if (GameConfGetKeyValue(gamedata, keyName, buffer, sizeof(buffer))) {
-					chatColorInfo[i][ChatColorInfo_Supported]		= StrEqual(buffer, "true");
+					chatColorInfo[i].ChatColorInfo_Supported        = StrEqual(buffer, "true");
 				}
 
 				Format(keyName, sizeof(keyName), "%s_subjecttype",	chatColorNames[i]);
 				if (GameConfGetKeyValue(gamedata, keyName, buffer, sizeof(buffer))) {
-					chatColorInfo[i][ChatColorInfo_SubjectType]		= view_as<ChatColorSubjectType>(StringToInt(buffer));
+					chatColorInfo[i].ChatColorInfo_SubjectType      = view_as<ChatColorSubjectType>(StringToInt(buffer));
 				}
 			}
 
@@ -449,9 +507,9 @@ static stock int Color_GetChatColorInfo(int &index, int &subject=CHATCOLOR_NOSUB
 		index = 0;
 	}
 
-	while (!chatColorInfo[index][ChatColorInfo_Supported]) {
+	while (!chatColorInfo[index].ChatColorInfo_Supported) {
 
-		int alternative = chatColorInfo[index][ChatColorInfo_Alternative];
+		int alternative = chatColorInfo[index].ChatColorInfo_Alternative;
 
 		if (alternative == -1) {
 			index = 0;
@@ -466,10 +524,9 @@ static stock int Color_GetChatColorInfo(int &index, int &subject=CHATCOLOR_NOSUB
 	}
 
 	int newSubject = CHATCOLOR_NOSUBJECT;
-	ChatColorSubjectType type = chatColorInfo[index][ChatColorInfo_SubjectType];
+	ChatColorSubjectType type = chatColorInfo[index].ChatColorInfo_SubjectType;
 
 	switch (type) {
-
 		case ChatColorSubjectType_none: {
 		}
 		case ChatColorSubjectType_player: {
@@ -505,7 +562,7 @@ static stock int Color_GetChatColorInfo(int &index, int &subject=CHATCOLOR_NOSUB
 	if (type > ChatColorSubjectType_none &&
 		((subject != CHATCOLOR_NOSUBJECT && subject != newSubject) || newSubject == CHATCOLOR_NOSUBJECT || !isSayText2_supported))
 	{
-		index = chatColorInfo[index][ChatColorInfo_Alternative];
+		index = chatColorInfo[index].ChatColorInfo_Alternative;
 		newSubject = Color_GetChatColorInfo(index, subject);
 	}
 


### PR DESCRIPTION
Updates old syntax enum struct to new. Moves initialization to the init function from global init (since bracket initialization is currently unsupported). Updates formatting stuff for consistency.