### PR TITLE
Fix Entity_GetRenderColor returning random alpha

### DIFF
--- a/scripting/include/smlib/entities.inc
+++ b/scripting/include/smlib/entities.inc
@@ -2026,7 +2026,7 @@ stock void Entity_GetRenderColor(int entity, int color[4])
 	}
 
 	for (int i=0; i < 4; i++) {
-		color[i] = GetEntData(entity, offset + i + 1, 1);
+		color[i] = GetEntData(entity, offset + i, 1);
 	}
 }
 


### PR DESCRIPTION
Hi,

So basically I had been holding for myself some years already two custom regression/unapplied bug fixes for the `transitional_syntax` branch: `Entity_SetParent` failing per commented `AddOutput` line, which affected games like HL2DM and got recently fixed, and also wrong index by a single unit offset for `Entity_GetRenderColor` (this PR commit) that causes unrelated data to be returned (namely an adjacent entity prop to the color one).

I recently thought it would be fine to PR this to you.

Thanks.